### PR TITLE
T295 accessibility link

### DIFF
--- a/app/assets/stylesheets/scholarspace.scss
+++ b/app/assets/stylesheets/scholarspace.scss
@@ -6,3 +6,7 @@ body {
 .image-masthead .background-container {
   filter: none;
 }
+
+.accessibility-form-link {
+  padding-top: 2.5em;
+}

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -7,9 +7,11 @@
     id: "file_download",
     data: { label: file_set.id },
     target: "_new" %>
-  <p /><%= link_to 'Report an accessibility issue with this item',
+  <% if Rails.configuration.respond_to?(:accessibility_url) %>
+    <p /><%= link_to t('hyrax.accessibility.link_label'),
     Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
     id: "accessibility_form",
     target: "_new" %> 
+  <% end %>
 <% end %>
 </div>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,0 +1,15 @@
+
+<div class="no-preview">
+<%= t('hyrax.works.show.no_preview') %>
+<% if Hyrax.config.display_media_download_link? %>
+  <p /><%= link_to t('hyrax.file_set.show.download'),
+    hyrax.download_path(file_set),
+    id: "file_download",
+    data: { label: file_set.id },
+    target: "_new" %>
+  <p /><%= link_to 'Report an accessibility issue with this item',
+    Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
+    id: "accessibility_form",
+    target: "_new" %> 
+<% end %>
+</div>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -2,13 +2,14 @@
 <div class="no-preview">
 <%= t('hyrax.works.show.no_preview') %>
 <% if Hyrax.config.display_media_download_link? %>
-  <p /><%= link_to t('hyrax.file_set.show.download'),
+  <p/><%= link_to t('hyrax.file_set.show.download'),
     hyrax.download_path(file_set),
     id: "file_download",
     data: { label: file_set.id },
+    class: "btn-lg",
     target: "_new" %>
   <% if Rails.configuration.respond_to?(:accessibility_url) %>
-    <p /><%= link_to t('hyrax.accessibility.link_label'),
+    <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
     Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
     id: "accessibility_form",
     target: "_new" %> 

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -6,7 +6,7 @@
     hyrax.download_path(file_set),
     id: "file_download",
     data: { label: file_set.id },
-    class: "btn-lg",
+    class: "btn btn-primary",
     target: "_new" %>
   <% if Rails.configuration.respond_to?(:accessibility_url) %>
     <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -10,9 +10,10 @@
               hyrax.download_path(file_set),
               target: :_blank,
               id: "file_download",
-              data: { label: file_set.id } %>
+              data: { label: file_set.id },
+              class: "btn-lg" %>
   <% if Rails.configuration.respond_to?(:accessibility_url) %>
-    <p /><%= link_to t('hyrax.accessibility.link_label'),
+    <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
       Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
       id: "accessibility_form",
       target: "_new" %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,26 @@
+
+<% if Hyrax.config.display_media_download_link? %>
+<div>
+  <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+  <%= image_tag thumbnail_url(file_set),
+                class: "representative-media",
+                alt: "",
+                role: "presentation" %>
+  <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+              hyrax.download_path(file_set),
+              target: :_blank,
+              id: "file_download",
+              data: { label: file_set.id } %>
+  <p /><%= link_to 'Report an accessibility issue with this item',
+              Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
+              id: "accessibility_form",
+              target: "_new" %> 
+</div>
+<% else %>
+<div>
+  <%= image_tag thumbnail_url(file_set),
+                class: "representative-media",
+                alt: "",
+                role: "presentation" %>
+</div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -11,7 +11,7 @@
               target: :_blank,
               id: "file_download",
               data: { label: file_set.id },
-              class: "btn-lg" %>
+              class: "btn btn-primary" %>
   <% if Rails.configuration.respond_to?(:accessibility_url) %>
     <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
       Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -11,10 +11,12 @@
               target: :_blank,
               id: "file_download",
               data: { label: file_set.id } %>
-  <p /><%= link_to 'Report an accessibility issue with this item',
-              Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
-              id: "accessibility_form",
-              target: "_new" %> 
+  <% if Rails.configuration.respond_to?(:accessibility_url) %>
+    <p /><%= link_to t('hyrax.accessibility.link_label'),
+      Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
+      id: "accessibility_form",
+      target: "_new" %>
+  <% end %> 
 </div>
 <% else %>
 <div>

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -97,4 +97,8 @@ Rails.application.configure do
 
   # Base for permanent URL links presented on item page
   config.permanent_url_base = "https://scholarspace-etds.library.gwu.edu/"
+
+    # URL template for link to GW LAI accessibility form
+  config.accessibility_url = "https://library.gwu.edu/found-problem?type_of_problem=a11y&a11y_problem_type=item&url=%{gwss_item_url}"
+
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -11,6 +11,8 @@ en:
     footer:
       copyright_html:       '<strong>Copyright &copy; 2020 <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a></strong> Licensed under the Apache License, Version 2.0'
       service_html:         'A service of <a href="https://lai.gwu.edu/" class="navbar-link" target="_blank">GW Libraries and Academic Innovation</a>'
+    accessibility:
+      link_label: 'Report an accessibility issue with this item' 
     search:
       form:
         option:


### PR DESCRIPTION
- Updates the `_pdf` and `_default` templates in `file_sets/media_display` (the second is used when a thumbnail is not available). 
- Adds a configuration line to `production.rb.template`
- Adds a label to `hyrax.en.yml`

Please test with works with thumbnails, if possible. (Thumbnail rendering isn't working in my instance for some reason.)