### PR TITLE
Added note to authors, updated contact form. Fixes #302

### DIFF
--- a/app/assets/stylesheets/scholarspace.scss
+++ b/app/assets/stylesheets/scholarspace.scss
@@ -10,3 +10,8 @@ body {
 .accessibility-form-link {
   padding-top: 2.5em;
 }
+
+.alert-info a {
+  color: #28659A;
+  text-decoration:underline; 
+}

--- a/app/views/hyrax/base/_note_to_authors.html.erb
+++ b/app/views/hyrax/base/_note_to_authors.html.erb
@@ -1,0 +1,5 @@
+<div class="alert alert-info">
+    <h2 class="sr-only">Notice to Authors</h2>
+    <p> If you are the author of this work and you have any questions about the information on this page, please use the <a href='/contact'>Contact form</a> to get in touch with us.
+    </p>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,0 +1,44 @@
+<% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
+<div class="row work-type">
+  <div class="col-xs-12">
+    <%= render 'work_type', presenter: @presenter %>
+  </div>
+  <div class="col-xs-12">&nbsp;</div>
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <%= render 'work_title', presenter: @presenter %>
+      </div>
+      <div class="panel-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.iiif_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <% end %>
+          <div class="col-sm-3 text-center">
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
+            <%= render 'citations', presenter: @presenter %>
+            <%= render 'social_media' %>
+          </div>
+          <div class="col-sm-9">
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+            <%= render 'note_to_authors', presenter: @presenter %>
+          </div>
+          <div class="col-sm-12">
+            <%= render 'relationships', presenter: @presenter %>
+            <%= render 'items', presenter: @presenter %>
+            <%# TODO: we may consider adding these partials in the future %>
+            <%# = render 'sharing_with', presenter: @presenter %>
+            <%# = render 'user_activity', presenter: @presenter %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -27,6 +27,8 @@ en:
     visibility:
       open:
          text: Open Access
+    contact_form:
+      notice: Please use this form to report a problem using GW ScholarSpace, to request a consultation with the GW LAI Scholarly Communications team, or to share feedback.
   simple_form:
     labels:
       defaults:


### PR DESCRIPTION
Observe that the note directing authors to use the contact form appears below the metadata, and that the introductory text on the contact form has been updated to reflect the name of our repository.