### PR TITLE
Bulkrax upgrade to 2.2.0; fixes #321

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'riiif', '~> 2.0'
 gem 'cookies_eu'
 
 #gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git'
-gem 'bulkrax', '2.1.1'
+gem 'bulkrax', '2.2.0'
 
 gem 'willow_sword', github: 'notch8/willow_sword'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (2.1.1)
+    bulkrax (2.2.0)
       bagit (~> 0.4)
       coderay
       iso8601 (~> 0.9.0)
@@ -925,7 +925,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.0)
-  bulkrax (= 2.1.1)
+  bulkrax (= 2.2.0)
   byebug
   capybara (>= 2.15)
   chromedriver-helper


### PR DESCRIPTION
There are some fixes to export functionality that it might be good to have available to experiment with, so I thought we would add this to the current release.   I'm not suggesting to test exports right now; please just confirm that this does not break imports for you.  Seems to work fine for me.