### PR TITLE
Fixes bug that broke fileset page #327

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -8,7 +8,7 @@
     data: { label: file_set.id },
     class: "btn btn-primary",
     target: "_new" %>
-  <% if Rails.configuration.respond_to?(:accessibility_url) %>
+  <% if (Rails.configuration.respond_to?(:accessibility_url)) && (@presenter.respond_to?(:permanent_url))  %>
     <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
     Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
     id: "accessibility_form",

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -12,7 +12,7 @@
               id: "file_download",
               data: { label: file_set.id },
               class: "btn btn-primary" %>
-  <% if Rails.configuration.respond_to?(:accessibility_url) %>
+  <% if (Rails.configuration.respond_to?(:accessibility_url)) && (@presenter.respond_to?(:permanent_url)) %>
     <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
       Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
       id: "accessibility_form",


### PR DESCRIPTION
Confirm that fileset pages now work and that accessibility links still appears on work-level pages. 