### PR TITLE
T335 hide download button embargoed

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -25,6 +25,7 @@ module Hyrax
     delegate :has?, :first, :fetch, to: :solr_document
 
     # Metadata Methods
+    # Added visibility for use in file_sets/media_display views
     delegate :title, :label, :description, :creator, :contributor, :subject,
              :publisher, :language, :date_uploaded,
              :embargo_release_date, :lease_expiration_date,

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -1,0 +1,112 @@
+module Hyrax
+  class FileSetPresenter
+    include ModelProxy
+    include PresentsAttributes
+    include CharacterizationBehavior
+    include WithEvents
+    include DisplaysImage
+
+    attr_accessor :solr_document, :current_ability, :request
+
+    # @param [SolrDocument] solr_document
+    # @param [Ability] current_ability
+    # @param [ActionDispatch::Request] request the http request context
+    def initialize(solr_document, current_ability, request = nil)
+      @solr_document = solr_document
+      @current_ability = current_ability
+      @request = request
+    end
+
+    # CurationConcern methods
+    delegate :stringify_keys, :human_readable_type, :collection?, :image?, :video?,
+             :audio?, :pdf?, :office_document?, :representative_id, :to_s, to: :solr_document
+
+    # Methods used by blacklight helpers
+    delegate :has?, :first, :fetch, to: :solr_document
+
+    # Metadata Methods
+    delegate :title, :label, :description, :creator, :contributor, :subject,
+             :publisher, :language, :date_uploaded,
+             :embargo_release_date, :lease_expiration_date,
+             :depositor, :keyword, :title_or_label, :keyword,
+             :date_created, :date_modified, :itemtype,
+             :original_file_id, :visibility,
+             to: :solr_document
+
+    def alpha_channels
+      []
+    end
+
+    def single_use_links
+      @single_use_links ||= SingleUseLink.where(itemId: id).map { |link| link_presenter_class.new(link) }
+    end
+
+    # The title of the webpage that shows this FileSet.
+    def page_title
+      "#{human_readable_type} | #{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
+    end
+
+    # The first title assertion
+    def first_title
+      title.first
+    end
+
+    # The link text when linking to the show page of this FileSet
+    def link_name
+      current_ability.can?(:read, id) ? first_title : 'File'
+    end
+
+    def editor?
+      current_ability.can?(:edit, solr_document)
+    end
+
+    def tweeter
+      TwitterPresenter.twitter_handle_for(user_key: depositor)
+    end
+
+    def license
+      return if solr_document.license.nil?
+      solr_document.license.first
+    end
+
+    def stats_path
+      Hyrax::Engine.routes.url_helpers.stats_file_path(self, locale: I18n.locale)
+    end
+
+    def events(size = 100)
+      super(size)
+    end
+
+    # This overrides the method in WithEvents
+    def event_class
+      solr_document.to_model.model_name.name
+    end
+
+    def fixity_check_status
+      Hyrax::FixityStatusPresenter.new(id).render_file_set_status
+    end
+
+    def parent
+      @parent_presenter ||= fetch_parent_presenter
+    end
+
+    def user_can_perform_any_action?
+      current_ability.can?(:edit, id) || current_ability.can?(:destroy, id) || current_ability.can?(:download, id)
+    end
+
+    private
+
+      def link_presenter_class
+        SingleUseLinkPresenter
+      end
+
+      def fetch_parent_presenter
+        ids = ActiveFedora::SolrService.query("{!field f=member_ids_ssim}#{id}",
+                                              fl: ActiveFedora.id_field)
+                                       .map { |x| x.fetch(ActiveFedora.id_field) }
+        Hyrax::PresenterFactory.build_for(ids: ids,
+                                          presenter_class: WorkShowPresenter,
+                                          presenter_args: current_ability).first
+      end
+  end
+end

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,7 +1,7 @@
 
 <div class="no-preview">
 <%= t('hyrax.works.show.no_preview') %>
-<% if Hyrax.config.display_media_download_link? %>
+<% if (Hyrax.config.display_media_download_link?) && (file_set.visibility == 'open') %>
   <p/><%= link_to t('hyrax.file_set.show.download'),
     hyrax.download_path(file_set),
     id: "file_download",

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -4,20 +4,23 @@
   <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
   <%= image_tag thumbnail_url(file_set),
                 class: "representative-media",
-                alt: "",
+                #alt: "",
+                alt: file_set.title,
                 role: "presentation" %>
-  <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+  <% if file_set.visibility == 'open' %>
+    <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
               hyrax.download_path(file_set),
               target: :_blank,
               id: "file_download",
               data: { label: file_set.id },
               class: "btn btn-primary" %>
-  <% if (Rails.configuration.respond_to?(:accessibility_url)) && (@presenter.respond_to?(:permanent_url)) %>
-    <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
-      Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
-      id: "accessibility_form",
-      target: "_new" %>
-  <% end %> 
+    <% if (Rails.configuration.respond_to?(:accessibility_url)) && (@presenter.respond_to?(:permanent_url)) %>
+      <p class="accessibility-form-link"/><%= link_to t('hyrax.accessibility.link_label'),
+        Rails.configuration.accessibility_url % {gwss_item_url: u(@presenter.permanent_url)},
+        id: "accessibility_form",
+        target: "_new" %>
+   <% end %> 
+  <% end %>
 </div>
 <% else %>
 <div>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -4,8 +4,7 @@
   <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
   <%= image_tag thumbnail_url(file_set),
                 class: "representative-media",
-                #alt: "",
-                alt: file_set.title,
+                alt: "",
                 role: "presentation" %>
   <% if file_set.visibility == 'open' %>
     <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),


### PR DESCRIPTION
Added logic to the `file_set` views to hide Download button and accessibility link when the file has a visibility other than `open`. This fix also required a small change to the `file_set` presenter (in order to make the `visibility` attribute available to the view).

#### Testing
1. Test on work with unembargoed PDF. 
2. Test on work with embargoed PDF.

I don't know if we embargo other kinds of documents. Right now, the change has been applied to the PDF view and the `default` view, which would get applied only in edge cases (like a CSV, for instance). But for Office documents, images, etc., there are distinct views, each of which would have to be overwritten. (They are not currently overwritten in the GWSS instance.) 