### PR TITLE
Added permanent_url method to file_set_presenter

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -95,6 +95,11 @@ module Hyrax
       current_ability.can?(:edit, id) || current_ability.can?(:destroy, id) || current_ability.can?(:download, id)
     end
 
+    # Adding method to create permanent URL for file_set view, for accessibility form
+    def permanent_url
+      Scholarspace::Application.config.permanent_url_base + "concern/file_sets/#{id}"
+    end
+
     private
 
       def link_presenter_class


### PR DESCRIPTION
Adding the `permanent_url` method to the `file_set_presenter` allows the same view logic to apply in this case as on the work view. I don't think it should have any side-effects, but let me know if you suspect otherwise.

Please confirm that the accessibility link appears and works as intended on the file sets view.