### PR TITLE
Removed required fields not applicable #341

### DIFF
--- a/app/forms/hyrax/gw_journal_issue_form.rb
+++ b/app/forms/hyrax/gw_journal_issue_form.rb
@@ -4,11 +4,11 @@ module Hyrax
   # Generated form for GwJournalIssue
   class GwJournalIssueForm < GwWorkForm
     self.model_class = ::GwJournalIssue
-    self.required_fields = [:title, :creator, :license, :rights_statement]
-    self.terms += [:resource_type, :volume, :issue, :gw_affiliation, :doi, :bibliographic_citation]
+    self.required_fields = [:title]
+    self.terms += [:creator, :license, :rights_statement, :resource_type, :volume, :issue, :gw_affiliation, :doi, :bibliographic_citation]
 
     def secondary_terms
-      super + [:volume, :issue]
+      super + [:creator, :license, :rights_statement, :volume, :issue]
     end
   end
 end

--- a/app/forms/hyrax/gw_journal_issue_form.rb
+++ b/app/forms/hyrax/gw_journal_issue_form.rb
@@ -5,7 +5,7 @@ module Hyrax
   class GwJournalIssueForm < GwWorkForm
     self.model_class = ::GwJournalIssue
     self.required_fields = [:title]
-    self.terms += [:creator, :license, :rights_statement, :resource_type, :volume, :issue, :gw_affiliation, :doi, :bibliographic_citation]
+    self.terms += [:resource_type, :volume, :issue, :gw_affiliation, :doi, :bibliographic_citation]
 
     def secondary_terms
       super + [:creator, :license, :rights_statement, :volume, :issue]


### PR DESCRIPTION
I removed the `creator`, `rights_statement`, and `license` fields from the `required_fields` array. I had to add them to the `secondary_terms` list, which pushes them toward the bottom of the list of additional fields. (Otherwise, they just disappeared.) But for journal issues, I don't know that these fields will be used all that often anyway. 

Test to confirm that creating a new journal issue works as expected and that only the `title` field is required.