### PR TITLE
Adds invisible honeypot type captcha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,3 +102,5 @@ gem 'blacklight_oai_provider', '~>6.1.1'
 gem 'dotenv-rails'
 
 gem 'recaptcha'
+
+gem 'invisible_captcha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,6 +479,8 @@ GEM
       activesupport
     iiif_manifest (0.5.0)
       activesupport (>= 4)
+    invisible_captcha (2.0.0)
+      rails (>= 5.0)
     io-like (0.3.1)
     iso8601 (0.9.1)
     jbuilder (2.11.3)
@@ -959,6 +961,7 @@ DEPENDENCIES
   fcrepo_wrapper
   hydra-role-management
   hyrax (= 2.9.6)
+  invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -36,6 +36,15 @@ module Hyrax
     # response to the user.
     def after_deliver; end
 
+#    def honeypot_fields
+#    {
+#      :my_custom_comment_body => 'Do not fill in this field, sucka!',
+#      :another_thingy => 'Really... do not fill out!'
+#    }
+#    end
+    
+    invisible_captcha only: [:create, :update], honeypot: :gwsshoney
+    
     private
 
       def build_contact_form

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 
 <%= form_for @contact_form, url: hyrax.contact_form_index_path,
-                            html: { class: 'form-horizontal' } do |f| %>
+                            html: { class: 'form-horizontal'} do |f| %>
   <%= f.text_field :contact_method, class: 'hide' %>
   <div class="form-group">
     <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
@@ -39,6 +39,7 @@
   <div class="form-group">
     <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
     <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+    <%= f.invisible_captcha :gwsshoney %>
   </div>
 
   <div class="form-group">

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,12 @@
+InvisibleCaptcha.setup do |config|
+  # config.honeypots           << ['more', 'fake', 'attribute', 'names']
+  config.visual_honeypots    = false  # switch to true for testing
+  # config.timestamp_threshold = 2
+  # config.timestamp_enabled   = true
+  # config.injectable_styles   = false
+  # config.spinner_enabled     = true
+
+  # Leave these unset if you want to use I18n (see below)
+  # config.sentence_for_humans     = 'If you are a human, ignore this field'
+  # config.timestamp_error_message = 'Sorry, that was too quick! Please resubmit.'
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,7 +1,7 @@
 en:
   hyrax:
     product_name:           "GW ScholarSpace"
-    local_product_version:  "1.6.2"
+    local_product_version:  "1.6.3"
     product_twitter_handle: ""
     institution_name:       "The George Washington University"
     institution_name_full:  "George Washington University"


### PR DESCRIPTION
To test:
- `bundle install`
- Confirm that normal form submission still succeeds (i.e. isn't broken)
- Modify `config/initializers/invisible_captcha.rb` to set `config.visual_honeypots` to `true`.  Fill out the form, including the "honeypot" form field.  Confirm that submitting the form redirects to an empty 200 response, and that it does not result in an actual form submission / email.

![image](https://user-images.githubusercontent.com/3451175/206724597-ac24972e-83aa-4c17-8a5e-0aae4e6aa4fe.png)
