### PR TITLE
T220 oai pmh

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -326,3 +326,5 @@ class CatalogController < ApplicationController
     false
   end
 end
+
+BlacklightOaiProvider::SolrDocumentProvider.register_format(Metadata::DublinCoreEtd.instance)

--- a/app/models/concerns/hyrax/solr_document/dublin_core_etd.rb
+++ b/app/models/concerns/hyrax/solr_document/dublin_core_etd.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'builder'
+
+module Hyrax
+    module SolrDocument
+        module DublinCoreEtd
+            # Overriding certain methods from this module & adding others
+            include Blacklight::Document::DublinCore
+            
+            def self.register_export_formats(document)
+                # This method called when SolrDocument includes this extension
+                document.will_export_as(:oai_dc_etd, "text/xml")
+                # Call parent module's method
+                super document
+            end
+
+            def get_additional_fields
+                # Returns a hash mapping an additional document field to a DC field and an attribute name, such that advisor => <dc:contributor type="advisor">
+                { :advisor => { :name => "contributor", :attr => "type" },
+                :committee_member => { :name => "contributor", :attr => "type" },
+                :degree => { :name => "description", :attr => "primo_field" },
+                :gw_affiliation => { :name => "description", :attr => "primo_field" } }
+            end
+
+            def to_oai_dc_etd
+                export_as("oai_dc_etd")
+            end
+
+            def export_as_oai_dc_etd 
+                # Generate XML for ETD's, using basic DC with a couple of extra attributes
+                # Based on Blacklight::Document::DublinCore.export_as_oai_dc_xml
+                xml = Builder::XmlMarkup.new
+                xml.tag!("oai_dc_etd:dc",
+                # Hacky --> We're not actually using a different schema
+                'xmlns:oai_dc_etd' => "http://www.openarchives.org/OAI/2.0/oai_dc/",
+                'xmlns:dc' => "http://purl.org/dc/elements/1.1/",
+                'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+                'xsi:schemaLocation' => %(http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd)) do
+                    addl_fields = get_additional_fields
+                    # Extend the list of fields to include
+                    dc_fields = dublin_core_field_names + addl_fields.keys
+                    self.to_semantic_values.select { |field, values| dc_fields.include? field.to_sym }.each do |field, values|
+                        Array.wrap(values).each do |v|
+                            # Only use attributes if one of the special ETD fields
+                            etd_field = addl_fields.fetch(field, nil)
+                            if etd_field
+                                tag_name = etd_field[:name]
+                                attr_name = etd_field[:attr].to_sym
+                                xml.tag!("dc:#{tag_name}", v, attr_name => field)
+                            else
+                                xml.tag! "dc:#{field}", v
+                            end
+                        end
+                    end
+                end
+                xml.target!
+            end
+        end
+    end
+end

--- a/app/models/metadata/dublin_core_etd.rb
+++ b/app/models/metadata/dublin_core_etd.rb
@@ -1,0 +1,11 @@
+# Implementation of a modified Dublin Core OAI format for electronic theses/disserations
+# Based on example here: https://github.com/nims-dpfc/nims-hyrax/blob/d8b6e6277467ba384d8b9d73b2fc0d9aa5213403/hyrax/app/models/metadata/jpcoar.rb
+class Metadata::DublinCoreEtd < OAI::Provider::Metadata::DublinCore
+
+    def initialize
+        # Use the original DublinCore implementation from the ruby_oai gem
+        # Just update the prefix
+        super
+        @prefix = 'oai_dc_etd'
+    end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -38,17 +38,53 @@ class SolrDocument
     subject: Solrizer.solr_name('keyword'),
     date: Solrizer.solr_name('date_created'),
     language: Solrizer.solr_name('language'),
-    #advisor: Solrizer.solr_name('advisor')
     type: Solrizer.solr_name('resource_type')
   )
+  def add_relator_terms(field_name, relator_term, subfield: false)
+    # Returns an array of strings consisting of the SolrDocument value for the given Solr field name, along with the specified relator term and, if present, the field value in the $$Q subfield location (for Primo VE hyperlink display)
+    # Using .try because the field might be nil
+    field_ary = self[Solrizer.solr_name(field_name)].try(:map) do |field_value| 
+      if subfield
+        "#{field_value}#{relator_term}$$Q#{field_value}"
+      else
+        "#{field_value}#{relator_term}"
+      end
+    end
+    field_ary
+  end
   # Overriding Blacklight::::Document::SemanticFields#to_smemantic_fields
+  # in order to provide custom metadata for exporting theses/dissertations
   def to_semantic_values
     @semantic_value_hash = super
-    # Look up the advisor field
-    advisor = self[Solrizer.solr_name('advisor')] 
-    if advisor
-      # replicates value construction from original method to ensure values as an array
-      @semantic_value_hash[:contributor] = advisor.flatten.compact
+    # Mapping for adding relator terms to DC fields for specific fields in the SolrDocument
+    # Including standard DC field so that we don't override those values
+    contributor_terms = {'contributor' => '',
+                        'advisor' => ', advisor.',
+                        'committee_member' => ', committee member.'
+                        }
+    description_terms = {'description' => '',
+                        'degree' => ' (Degree).',
+                        'gw_affiliation' => ' (GW Affiliation).'
+                        }
+    # Determine resource type
+    if self[Solrizer.solr_name('resource_type')].include? 'Thesis or Dissertation'
+      # Get advisors and committee members 
+      contributors = contributor_terms.map do |field_name, relator_term|
+        add_relator_terms(field_name, relator_term, subfield: true)
+      end
+      # Get degree and affiliation & add to description field  
+      description = description_terms.map do |field_name, relator_term|
+        add_relator_terms(field_name, relator_term)
+      end
+      # Add the repository identifier to the DC metadata (by default it's part of the header, but we can't apply Primo norm rules to the header)
+      identifier = "#{OAI_CONFIG[:provider][:record_prefix]}:#{self['id']}"
+      # Merge as new hash with existing field semantics
+      # Using compact to remove any nils
+      @semantic_value_hash.merge!(
+        contributor: contributors.flatten.compact,
+        description: description.flatten.compact,
+        identifier: Array(identifier)
+      )
     end
     @semantic_value_hash
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -67,7 +67,7 @@ class SolrDocument
                         'gw_affiliation' => ' (GW Affiliation).'
                         }
     # Determine resource type
-    if self[Solrizer.solr_name('resource_type')].include? 'Thesis or Dissertation'
+    if self.fetch(Solrizer.solr_name('resource_type'), []).include? 'Thesis or Dissertation'
       # Get advisors and committee members 
       contributors = contributor_terms.map do |field_name, relator_term|
         add_relator_terms(field_name, relator_term, subfield: true)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -31,11 +31,23 @@ class SolrDocument
   field_semantics.merge!(
     title: Solrizer.solr_name('title'),
     creator: Solrizer.solr_name('creator'),
+    contributor: Solrizer.solr_name('contributor'),
     description: Solrizer.solr_name('description'),
     publisher: Solrizer.solr_name('publisher'),
     identifier: Solrizer.solr_name('doi'),
     subject: Solrizer.solr_name('keyword')
   )
+  # Overriding Blacklight::::Document::SemanticFields#to_smemantic_fields
+  def to_semantic_values
+    @semantic_value_hash = super
+    # Look up the advisor field
+    advisor = self[Solrizer.solr_name('advisor')] 
+    if advisor
+      # replicates value construction from original method to ensure values as an array
+      @semantic_value_hash[:contributor] = advisor.flatten.compact
+    end
+    @semantic_value_hash
+  end
 
   def gw_affiliation
     self[Solrizer.solr_name('gw_affiliation')]

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -35,7 +35,11 @@ class SolrDocument
     description: Solrizer.solr_name('description'),
     publisher: Solrizer.solr_name('publisher'),
     identifier: Solrizer.solr_name('doi'),
-    subject: Solrizer.solr_name('keyword')
+    subject: Solrizer.solr_name('keyword'),
+    date: Solrizer.solr_name('date_created'),
+    language: Solrizer.solr_name('language'),
+    #advisor: Solrizer.solr_name('advisor')
+    type: Solrizer.solr_name('resource_type')
   )
   # Overriding Blacklight::::Document::SemanticFields#to_smemantic_fields
   def to_semantic_values

--- a/config/initializers/oai_config.rb
+++ b/config/initializers/oai_config.rb
@@ -12,7 +12,7 @@ OAI_CONFIG =
             limit: 25,            # number of records returned with each request, default: 15
             #supported_formats: ['oai_dc'],
             set_fields: [
-            { label: 'type', solr_field: 'human_readable_type_tesim' }
+            { label: 'type', solr_field: 'has_model_ssim' }
           ]
 
         },

--- a/config/initializers/oai_config.rb
+++ b/config/initializers/oai_config.rb
@@ -10,7 +10,7 @@ OAI_CONFIG =
         },
         document: {
             limit: 25,            # number of records returned with each request, default: 15
-            #supported_formats: ['oai_dc'],
+            supported_formats: ['oai_dc', 'oai_dc_etd'],
             set_fields: [
             { label: 'type', solr_field: 'has_model_ssim' }
           ]


### PR DESCRIPTION
Resolves #220 

Creates OAI route (`/catalog/oai`) with modified Dublin Core scheme for ETD's. 

### Testing
1. Install dependencies with `bundle install`. 
2. If not already present in the repository, create some works of type `GwEtd`. Be sure to include data in the `Advisor`, `Committee Member`, `Degree` and `GW Affiliation` fields.
3. Confirm that these works are visible at the route `catalog/oai?verb=ListRecords&metadataPrefix=oai_dc&set=type:GwEtd`
4. Confirm that these works are also visible at the route `https://ec2-3-137-137-212.us-east-2.compute.amazonaws.com/catalog/oai?verb=ListRecords&metadataPrefix=oai_dc_etd&set=type:GwEtd`
5. View the XML source for the latter page to confirm that the following elements/attributes are present:
    - `<dc:contributor type="advisor">` 
    - `<dc:contributor type="committee_member">`
    - `<dc:description primo_field="gw_affiliation">`
    - `<dc:description primo_field="degree">`
6. Verify that other OAI functionality works: `ListSets`, `ListIdentifiers`, `ListMetadataFormats`, and that pagination works (by using the `Resume` button at the bottom of a page of multi-page results).   