### PR TITLE
Add migration version and remove extra comma

### DIFF
--- a/db/migrate/20170509232172_change_proxy_deposit_request_generic_file_id_to_work_id.hyrax.rb
+++ b/db/migrate/20170509232172_change_proxy_deposit_request_generic_file_id_to_work_id.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222239)
-class ChangeProxyDepositRequestGenericFileIdToWorkId < ActiveRecord::Migration
+class ChangeProxyDepositRequestGenericFileIdToWorkId < ActiveRecord::Migration[5.0]
   def change
     rename_column :proxy_deposit_requests, :generic_file_id, :generic_id if ProxyDepositRequest.column_names.include?('generic_file_id')
   end

--- a/db/migrate/20170509232216_create_mailboxer.mailboxer_engine.rb
+++ b/db/migrate/20170509232216_create_mailboxer.mailboxer_engine.rb
@@ -28,7 +28,7 @@ class CreateMailboxer < ActiveRecord::Migration[5.0]
       t.column :conversation_id, :integer
       t.column :draft, :boolean, :default => false
       t.string :notification_code, :default => nil
-      t.references :notified_object, :polymorphic => true, , index: { name: 'mailboxer_notifications_notified_object' }
+      t.references :notified_object, :polymorphic => true, index: { name: 'mailboxer_notifications_notified_object' }
       t.column :attachment, :string
       t.column :updated_at, :datetime, :null => false
       t.column :created_at, :datetime, :null => false


### PR DESCRIPTION
Fixes #374, errors with database migration files.

- Adds a migration version in `db/migrate/20170509232172_change_proxy_deposit_request_generic_file_id_to_work_id.hyrax.rb`
- Removes an extra comma in `db/migrate/20170509232216_create_mailboxer.mailboxer_engine.rb`