### PR TITLE
Organize gemfile to remove duplicate categories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,48 +41,24 @@ gem 'redis', '~> 4.0'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-end
-
-group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-end
-
-group :test do
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
-end
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'hyrax', '2.9.6'
-group :development, :test do
-  gem 'solr_wrapper', '>= 0.3'
-end
 
 gem 'hydra-role-management'
 
 gem 'rsolr', '>= 1.0', '< 3'
+
 gem 'bootstrap-sass', '~> 3.0'
+
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
+
 gem 'jquery-rails'
+
 gem 'devise'
+
 gem 'devise-guests', '~> 0.6'
-group :development, :test do
-  gem 'fcrepo_wrapper'
-  gem 'rspec-rails'
-end
 
 gem 'riiif', '~> 2.0'
 
@@ -104,3 +80,30 @@ gem 'dotenv-rails'
 gem 'recaptcha'
 
 gem 'invisible_captcha'
+
+
+group :development, :test do
+  gem 'pry'
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'solr_wrapper', '>= 0.3'
+  gem 'launchy'
+  gem 'fcrepo_wrapper'
+  gem 'rspec-rails'
+end
+
+group :development do
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  gem 'web-console', '>= 3.3.0'
+  gem 'listen', '>= 3.0.5', '< 3.2'
+  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  # Adds support for Capybara system testing and selenium driver
+  gem 'capybara', '>= 2.15'
+  gem 'selenium-webdriver'
+  # Easy installation and use of chromedriver to run system tests with Chrome
+  gem 'chromedriver-helper'
+end


### PR DESCRIPTION
Small quality-of-life pull request for cleaning up the formatting of the Gemfile. Consolidates duplicated `development` and `test` gem groupings, and moves production gems above those groupings. 