### PR TITLE
Change not_found route to handle non-html urls

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
 
-  match '*unmatched', to: 'errors#not_found', via: :all
+  match '*path', to: 'errors#not_found', via: :all, format: false, defaults: { format: 'html' }
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
Fixes #402 by changing the `errors#not_found` route line to also handle URLs that do not end in `.html`