### PR TITLE
428 ga4 analytics fix 

### DIFF
--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -26,7 +26,7 @@ signed in %>
 <%= render 'shared/appearance_styles' %>
 
 <!-- Google Analytics -->
-<%= render partial: 'shared/ga', formats: [:html] %>
+<%= render partial: 'shared/ga4', formats: [:html] %>
 
 <!-- for extras, e.g., a favicon -->
 <%= render partial: '/head_tag_extras', formats: [:html] %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -4,8 +4,10 @@
 analytics:
   ga4:
     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-#   app_name: GOOGLE_OAUTH_APP_NAME
-#   app_version: GOOGLE_OAUTH_APP_VERSION
-#   privkey_path: GOOGLE_OAUTH_PRIVATE_KEY_PATH
-#   privkey_secret: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-#   client_email: GOOGLE_OAUTH_CLIENT_EMAIL
+    #app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+    #app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+    #privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+    #privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+    #client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+  google:
+    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -2,7 +2,7 @@
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
 analytics:
-  google:
+  ga4:
     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
 #   app_name: GOOGLE_OAUTH_APP_NAME
 #   app_version: GOOGLE_OAUTH_APP_VERSION

--- a/config/initializers/hyrax.rb.template
+++ b/config/initializers/hyrax.rb.template
@@ -37,7 +37,7 @@ Hyrax.config do |config|
   # Enable displaying usage statistics in the UI
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-  # config.analytics = false
+  config.analytics = true
 
   # Google Analytics tracking ID to gather usage statistics
   # config.google_analytics_id = 'UA-99999999-1'

--- a/config/initializers/hyrax.rb.template
+++ b/config/initializers/hyrax.rb.template
@@ -37,7 +37,7 @@ Hyrax.config do |config|
   # Enable displaying usage statistics in the UI
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-  config.analytics = true
+  # config.analytics = false
 
   # Google Analytics tracking ID to gather usage statistics
   # config.google_analytics_id = 'UA-99999999-1'

--- a/example.env
+++ b/example.env
@@ -74,4 +74,6 @@ FEDORA_PASSWORD=
 DEV_ADMIN_USER_EMAIL='admin@example.com'
 DEV_ADMIN_USER_PASSWORD='password'
 ##------Google Analytics------------------------------------
+HYRAX_ANALYTICS_PROVIDER=ga4
+HYRAX_ANALYTICS=true
 GOOGLE_ANALYTICS_ID=


### PR DESCRIPTION
Fixed #428 

Google Analytics GA4 code should appear in the header of every page:

```
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'G-9999999');
</script>
```

Note that there are new variables to set in the `example.env`.