### PR TITLE
Fixes sorting on collections pages

### DIFF
--- a/app/controllers/hyrax/collections_controller_behavior_decorator.rb
+++ b/app/controllers/hyrax/collections_controller_behavior_decorator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# OVERRIDE Hyrax v3.6.0 to sort subcollections by title
+# Fix thanks to https://github.com/scientist-softserv/palni-palci/pull/802/files
+module Hyrax
+  module CollectionsControllerBehaviorDecorator
+    def load_member_subcollections
+      super
+      return if @subcollection_docs.blank?
+
+      @subcollection_docs.sort_by! { |doc| doc.title.first&.downcase }
+    end
+
+    def show
+      # OVERRIDE Hyrax 3.6.0 to initialize the works sort default field instead of using relevance
+      params[:sort] ||= Hyrax::Collections::CollectionMemberSearchServiceDecorator::DEFAULT_SORT_FIELD
+
+      super
+    end
+  end
+end
+
+Hyrax::CollectionsControllerBehavior.prepend Hyrax::CollectionsControllerBehaviorDecorator

--- a/app/services/hyrax/collections/collection_member_search_service_decorator.rb
+++ b/app/services/hyrax/collections/collection_member_search_service_decorator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v3.6.0 to sort subcollections by title
+module Hyrax
+  module Collections
+    module CollectionMemberSearchServiceDecorator
+      DEFAULT_SORT_FIELD = 'title_ssi asc'
+
+      def available_member_works
+        sort_field = user_params[:sort] || DEFAULT_SORT_FIELD
+        response, _docs = search_results do |builder|
+          builder.search_includes_models = :works
+          builder.merge(sort: sort_field)
+          builder
+        end
+        response
+      end
+    end
+  end
+end
+
+Hyrax::Collections::CollectionMemberSearchService.prepend Hyrax::Collections::CollectionMemberSearchServiceDecorator

--- a/app/services/hyrax/search_service_decorator.rb
+++ b/app/services/hyrax/search_service_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# Courtesy of https://github.com/scientist-softserv/palni-palci/blob/main/app/services/hyrax/search_service_decorator.rb
+module Hyrax
+  module SearchServiceDecorator
+    def search_results
+      builder = search_builder.with(user_params)
+      builder.page = user_params[:page] if user_params[:page]
+      builder.rows = (user_params[:per_page] || user_params[:rows]) if user_params[:per_page] || user_params[:rows]
+
+      builder = yield(builder) if block_given?
+      # OVERRIDE: without this merge, Blightlight seems to ignore the sort params on Collections
+      builder.merge(sort: user_params[:sort]) if user_params[:sort]
+      response = repository.search(builder)
+
+      if response.grouped? && grouped_key_for_results
+        [response.group(grouped_key_for_results), []]
+      elsif response.grouped? && response.grouped.length == 1
+        [response.grouped.first, []]
+      else
+        [response, response.documents]
+      end
+    end
+  end
+end
+
+Hyrax::SearchService.prepend Hyrax::SearchServiceDecorator


### PR DESCRIPTION
Fixes #411 and #414  (Though see comments on #414 for a divergence from Hyrax 3 we may want to address.)

Thanks to the helpful folks on the Samvera Slack, I learned that this behavior is a bug traceable to Blacklight, but fortunately, the folks at PALNI/PALCI have a [fix](https://github.com/samvera/hyrax/pull/6326/files/686b5867114b065aa3728559c4e5086486bd9893#diff-ceefbbb73f2e092e5d797adb66c5512233e91f96d6a8a23d23ca3f6e2168b529), which I applied to our app verbatim, and which seems to have resolved the problem.

Testing:
1. Confirm that sorting the works within collections from the Dashboard > Collections page performs as expected for all sort parameters.
2. Confirm that sorting behavior is unchanged/works as expected from the main catalog search page.