### PR TITLE
T432 local development mode instructions

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,5 +1,6 @@
 # Place any default configuration for solr_wrapper here
 port: 8984
+instance_dir: tmp/fcrepo4
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-development-data
 persist: false

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -5,5 +5,5 @@ instance_dir: tmp/solr-development
 persist: false
 dir: solr/conf/
 name: hydra-development
-version: 6.4.1
+version: 6.4.2
 verbose: true

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ After bringing down the containers, run this script (with `sudo`) to clear out a
 
 ## Local Development Installation
 
-For development of the Rails application, ScholarSpace can be run locally on macOS. This does not create a 1-to-1 replication of the production environment and does not use utilize Docker, but is intended as a minimal 
+ScholarSpace can be run locally on macOS. This does not create a 1-to-1 replication of the production environment and does not use utilize Docker, but is intended as a minimal setup for development of the Rails application.
 
 ### Requirements
 - Installation of [FITS 1.5.0](https://projects.iq.harvard.edu/fits/home)
@@ -230,6 +230,12 @@ For development of the Rails application, ScholarSpace can be run locally on mac
     # Path to the file derivatives creation tool
     config.libreoffice_path = "/usr/local/bin/soffice"
     ```
+
+- Installation of [PostgreSQL 15](https://www.postgresql.org/)
+  - If using Homebrew:
+   - `brew install postgresql@15`
+  - Manual install:
+   - [Download Page](https://www.postgresql.org/download/macosx/)
 
 ### Configuration
 - In `config/environments/development.rb`, change the `config.active_job_queue_adapter` to `:inline` rather than `:sidekiq`

--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ ScholarSpace can be run locally on macOS. This does not create a 1-to-1 replicat
 
 - Installation of [PostgreSQL 15](https://www.postgresql.org/)
   - If using Homebrew:
-   - `brew install postgresql@15`
+    - `brew install postgresql@15`
   - Manual install:
-   - [Download Page](https://www.postgresql.org/download/macosx/)
+    - [Download Page](https://www.postgresql.org/download/macosx/)
 
 ### Configuration
 - In `config/environments/development.rb`, change the `config.active_job_queue_adapter` to `:inline` rather than `:sidekiq`

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ ScholarSpace can be run locally on macOS. This does not create a 1-to-1 replicat
   - Manual install:
     - [Download Page](https://www.postgresql.org/download/macosx/)
 
+- An installed version of Ruby 2.7.3
+  - This can achieved through [RBENV](https://github.com/rbenv/rbenv) or [RVM](https://rvm.io/)
+
+### Clone and Setup Repository
+- Clone this repository to your local machine.
+- Navigate to the folder where installed, and ensure you are running Ruby 2.7.3
+- Run `bundle` in order to install ruby gems from the Gemile
+
 ### Configuration
 - In `config/environments/development.rb`, change the `config.active_job_queue_adapter` to `:inline` rather than `:sidekiq`
 - Minimal .env configuration:

--- a/README.md
+++ b/README.md
@@ -205,3 +205,35 @@ docker volume rm $(docker volume ls -q)
 ```
 After bringing down the containers, run this script (with `sudo`) to clear out all persistent storage, including the Rails database, before bringing back up the containers. 
 
+## Running a Local Development Instance
+
+For development of the Rails application, ScholarSpace can be run locally. 
+
+### Requirements
+- Installation of [FITS](https://projects.iq.harvard.edu/fits/home)
+  - This can be found on the [download page](https://projects.iq.harvard.edu/fits/downloads)
+  - If you are installing via Homebrew, this can be installed by running `brew install fits` in a terminal.
+  - Once installed, modify the `config.fits_path` in `config/initializers/hyrax.rb` to point to the installation path for FITS, e.g. `"/usr/local/bin/fits-1.5.0/fits.sh"`. 
+    - This path can be found by running `which fits` in your terminal. 
+- Installation of [LibreOffice](https://www.libreoffice.org/)
+  - This can be found on the [download page](https://www.libreoffice.org/download/download-libreoffice/)
+  - If installing via Homebrew, this can be installed by running `brew install --cask libreoffice`
+  - Once installed, modify the  `config.libreoffice_path` in `config/initializers/hyrax.rb` to point to the installation path for LibreOffice
+    - This path can be found by running `which soffice` in your terminal. 
+
+### Configuration
+- In `config/environments/development.rb`, change the `config.active_job_queue_adapter` to `:inline` rather than `:sidekiq`
+- .env configuration:
+  - `RAILS_ENV=development`
+  - `SOLR_URL=http://localhost`
+  - `FEDORA_URL=https://localhost`
+
+### Preparing the Databases
+
+- In a terminal, run `rails db:{drop,create,migrate}` in order to drop the development database (if it exists), create a new development database, and run the database migrations. 
+
+### Launching the Server
+
+- In a terminal, run `rails hydra:server`
+- If this is the first time you have run this command, it will install an instance of Solr and an instance of Fedora4 in `tmp`
+

--- a/config/blacklight.yml.template
+++ b/config/blacklight.yml.template
@@ -1,9 +1,9 @@
 development:
   adapter: solr
-  url:  <%=ENV['SOLR_URL'] || 'http://127.0.0.1' %>:<%= ENV['SOLR_PORT'] || ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_DEV'] || 'hydra-development' %>
+  url: <%=ENV['SOLR_URL'] || 'http://localhost' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/<%= ENV['SOLR_CORE_DEV'] || 'hydra-development' %>
 test: &test
   adapter: solr
-  url: <%=ENV['SOLR_URL'] || 'http://127.0.0.1'%>:<%= ENV['SOLR_PORT'] || ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_TEST'] || 'hydra-test' %>
+  url: <%=ENV['SOLR_URL'] || 'http://localhost' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/<%= ENV['SOLR_CORE_TEST'] || 'solr-core-test' %>
 production:
   adapter: solr
   url: <%=ENV['SOLR_URL']%>:<%= ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_PROD'] %>

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -8,7 +8,7 @@ default: &default
   timeout: 5000
 
 development:
-  database: <%= ENV["HYRAX_DB_DEV"] %>
+  database: <%= ENV["HYRAX_DB_DEV"] || 'gwss_dev' %>
   <<: *default
 
 production:
@@ -16,5 +16,5 @@ production:
   <<: *default
 
 test:
-  database: <%= ENV["HYRAX_DB_TEST"] %>
+  database: <%= ENV["HYRAX_DB_TEST"] || 'gwss_test' %>
   <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/fedora.yml.template
+++ b/config/fedora.yml.template
@@ -1,15 +1,15 @@
 development:
-  user:  <%= ENV['FEDORA_USERNAME'] %>
-  password: <%= ENV['FEDORA_PASSWORD'] %>
-  url: <%= ENV['FEDORA_URL'] || ENV['FEDORA_URL']%>:<%= ENV['FEDORA_PORT'] || ENV['FEDORA_PORT'] %>/<%= ENV['FEDORA_BASE'] %>
+  user:  <%= ENV['FEDORA_USERNAME'] || 'fedora_user' %>
+  password: <%= ENV['FEDORA_PASSWORD'] || 'password' %>
+  url: <%= ENV['FEDORA_URL'] || 'http://localhost' %>:<%= ENV['FEDORA_PORT'] || '8984' %>/<%= ENV['FEDORA_BASE'] || 'rest' %>
   base_path: /dev
 test:
-  user:  <%= ENV['FEDORA_USERNAME'] %>
-  password: <%= ENV['FEDORA_PASSWORD'] %>
-  url: <%= ENV['FEDORA_URL'] || ENV['FEDORA_URL']%>:<%= ENV['FEDORA_PORT'] || ENV['FEDORA_PORT'] %>/<%= ENV['FEDORA_BASE'] %>
+  user:  <%= ENV['FEDORA_USERNAME'] || 'fedora_user' %>
+  password: <%= ENV['FEDORA_PASSWORD'] || 'password' %>
+  url: <%= ENV['FEDORA_URL'] || 'http://localhost' %>:<%= ENV['FEDORA_PORT'] || '8984' %>/<%= ENV['FEDORA_BASE'] || 'rest' %>
   base_path: /test
 production:
-  user:  <%= ENV['FEDORA_USERNAME'] %>
-  password: <%= ENV['FEDORA_PASSWORD'] %>
-  url: <%= ENV['FEDORA_URL'] %>:<%= ENV['FEDORA_PORT'] %>/<%= ENV['FEDORA_BASE'] %>
+  user:  <%= ENV['FEDORA_USERNAME'] || 'fedora_user' %>
+  password: <%= ENV['FEDORA_PASSWORD'] || 'password' %>
+  url: <%= ENV['FEDORA_URL'] || 'http://localhost' %>:<%= ENV['FEDORA_PORT'] || '8984' %>/<%= ENV['FEDORA_BASE'] || 'rest' %>
   base_path: /prod

--- a/config/solr.yml.template
+++ b/config/solr.yml.template
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: <%=ENV['SOLR_URL'] || 'http://127.0.0.1' %>:<%= ENV['SOLR_PORT'] || ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_DEV'] || 'hydra-development' %>
+  url: <%=ENV['SOLR_URL'] || 'http://localhost' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/<%= ENV['SOLR_CORE_DEV'] || 'hydra-development' %>
 test:
-  url: <%=ENV['SOLR_URL'] || 'http://127.0.0.1'%>:<%= ENV['SOLR_PORT'] || ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_TEST'] || 'hydra-test' %>
+  url: <%=ENV['SOLR_URL'] || 'http://localhost' %>:<%= ENV['SOLR_PORT'] || '8983' %>/solr/<%= ENV['SOLR_CORE_TEST'] || 'hydra-test' %>
 production:
-  url: <%=ENV['SOLR_URL']%>:<%= ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_PROD'] %>
+  url: <%=ENV['SOLR_URL'] || 'http://localhost' %>:<%= ENV['SOLR_PORT'] %>/solr/<%= ENV['SOLR_CORE_PROD'] %>


### PR DESCRIPTION
Will close #432 

Adds instructions to the README for running using a local development setup sans-Docker on Mac. 

Tried to figure out the bare minimum of configuration settings required in the `.env` for running in this version, and included the results of that in the README. I added some default values for the Solr and Fedora development and test URLs in the templates. 

To test:
 - Follow the instructions beginning at "Local Development Installation". If successful, should end up with a fully functional local development instance running in browser at `localhost:3000`.