### PR TITLE
T419 About & Help pages updated with accordion styles

### DIFF
--- a/app/assets/stylesheets/scholarspace/components/_accordion.scss
+++ b/app/assets/stylesheets/scholarspace/components/_accordion.scss
@@ -1,0 +1,46 @@
+// Styling accordions on about & help to match GW conventions
+
+.accordion {
+    .card {
+        margin: 1rem 0;
+        &:first-of-type {
+            margin-top: 0;
+        }
+
+        .card-header {
+            padding: 0.3rem;
+            background-color: $gw-light-blue;
+            button {
+                padding: 0.5rem;
+                font-size: 1rem;
+                font-weight: 200;
+                color: $gw-white;
+
+                &::before {
+                    float: left;
+                    width: 20px;
+                    height: 20px;
+                    margin-right: 0.5rem;
+                    content: "";
+                    border: 2px solid $gw-hover-buff;
+                    border-radius: 50%;
+                    background-image: linear-gradient($gw-hover-buff,$gw-hover-buff),none;
+                    background-repeat: no-repeat,no-repeat;
+                    background-position: center center,center center;
+                    background-size: 10px 2px,2px 10px;
+                }
+
+                &.collapsed {
+                    &::before {
+                        content: "";
+                        background-image: linear-gradient($gw-hover-buff,$gw-hover-buff),linear-gradient($gw-hover-buff,$gw-hover-buff);
+                    }
+                }
+            }
+        }
+
+        .card-body {
+            margin: 1rem 0;
+        }
+    }
+}

--- a/app/assets/stylesheets/scholarspace/components/_accordion.scss
+++ b/app/assets/stylesheets/scholarspace/components/_accordion.scss
@@ -1,11 +1,12 @@
 // Styling accordions on about & help to match GW conventions
+.collapse,
+.collapsing {
+  max-height: 50vh;
+}
 
 .accordion {
     .card {
-        margin: 1rem 0;
-        &:first-of-type {
-            margin-top: 0;
-        }
+        padding-bottom: 1rem;
 
         .card-header {
             padding: 0.3rem;
@@ -40,7 +41,7 @@
         }
 
         .card-body {
-            margin: 1rem 0;
+            padding-top: 1rem;
         }
     }
 }

--- a/app/assets/stylesheets/scholarspace/scholarspace.scss
+++ b/app/assets/stylesheets/scholarspace/scholarspace.scss
@@ -27,3 +27,4 @@
 @import "components/homepage";
 @import "components/search";
 @import "components/work";
+@import "components/accordion";

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -276,18 +276,16 @@ end
 
 # -- Styling and content blocks
 
+featured_researcher_html = File.open("#{Rails.root}/spec/fixtures/content_blocks/featured_researcher.html")
+about_page_html = File.open("#{Rails.root}/spec/fixtures/content_blocks/about_page.html")
+help_page_html = File.open("#{Rails.root}/spec/fixtures/content_blocks/help_page.html")
+
 ContentBlock.find_or_create_by(name: "header_background_color").update!(value: "#FFFFFF")
 ContentBlock.find_or_create_by(name: "header_text_color").update!(value: "#444444")
 ContentBlock.find_or_create_by(name: "link_color").update!(value: "#28659A")
 ContentBlock.find_or_create_by(name: "footer_link_color").update!(value: "#FFFFFF")
 ContentBlock.find_or_create_by(name: "primary_buttom_background_color").update!(value: "#28659A")
 
-featured_researcher_text = "Established in 2016, the GW Undergraduate Review (GWUR) is the premier publication of research from undergraduate students at George Washington University. Its mission is to promote undergraduate research on GW’s campus through events, workshops, and the annual publication of a peer-reviewed journal. GWUR is entirely student-run and is supported by the Office of the Vice Provost for Research and GW Libraries and Academic Innovation."
-marketing_text = "Wow look at this, it is marketing text! This little text went to market. I don't know what is supposed to go here, sorry."
-announcement_text = "This is an announcement! Hello!"
-
-ContentBlock.find_or_create_by(name: "featured_researcher").update!(value: featured_researcher_text)
-ContentBlock.find_or_create_by(name: "marketing_text").update!(value: marketing_text)
-
-#TO-DO
-# figure out how to set the works to go in the etds admin set, rather than the default admin set
+ContentBlock.find_or_create_by(name: "featured_researcher").update!(value: featured_researcher_html.read)
+ContentBlock.find_or_create_by(name: "about_page").update!(value: about_page_html.read)
+ContentBlock.find_or_create_by(name: "help_page").update!(value: help_page_html.read)

--- a/spec/fixtures/content_blocks/about_page.html
+++ b/spec/fixtures/content_blocks/about_page.html
@@ -1,0 +1,255 @@
+<h1>About GW ScholarSpace</h1>
+<p>As the George Washington University&rsquo;s institutional repository, GW ScholarSpace provides free, public access, broad visibility, and long-term preservation for the research and scholarly works created by GW&rsquo;s faculty, staff and students, including electronic theses and dissertations (ETDs).</p>
+<h2>General Q&amp;A</h2>
+<div id="accordionExample" class="accordion">
+<div class="card">
+    <div id="headingOne" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne"> What works may I contribute to GW ScholarSpace? </button></h3>
+    </div>
+    <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+        <div class="card-body">
+            <p>Works produced or sponsored by GW faculty, researchers and staff may be shared through GW ScholarSpace, as well as ETDs and student works sponsored by GW faculty or programs.</p>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingTwo" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> What types of works are appropriate for GW ScholarSpace? </button></h3>
+    </div>
+    <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionExample">
+        <div class="card-body">
+            <p>Appropriate types of work may include, but are not limited to journal pre-prints and post-prints, datasets, working papers, technical reports, conference papers, student works, annual reports, newsletters, and Electronic Theses and Dissertations (ETDs).</p>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingThree" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree"> What are the advantages of submitting my works to GW ScholarSpace? </button></h3>
+    </div>
+    <div id="collapseThree" class="collapse" aria-labelledby="headingThree" data-parent="#accordionExample">
+        <div class="card-body">
+            <ul>
+                <li>Permanent links to each of your scholarly publications ensure long-term access.</li>
+                <li>Enhanced exposure to Google and other search engines increases your works&rsquo; visibility.</li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingFour" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour"> Will my works be publicly discoverable? </button></h3>
+    </div>
+    <div id="collapseFour" class="collapse" aria-labelledby="headingFour" data-parent="#accordionExample">
+        <div class="card-body">
+        <p>Yes, GW ScholarSpace is intended for public access. However, if your publisher requires a temporary embargo, we can facilitate that (see <a href="https://scholarspace.library.gwu.edu/about?locale=en#embargoes">Embargoes</a>).</p>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingFive" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive"> What kinds of materials should not be submitted to GW ScholarSpace? </button></h3>
+    </div>
+    <div id="collapseFive" class="collapse" aria-labelledby="headingFive" data-parent="#accordionExample">
+        <div class="card-body">
+            <p>GW ScholarSpace is not appropriate for works that include sensitive data such as personally identifiable information (PII) or protected health information (PHI).</p>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingSix" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseSix" aria-expanded="false" aria-controls="collapseSix"> What file formats are accepted in GW ScholarSpace? </button></h3>
+    </div>
+    <div id="collapseSix" class="collapse" aria-labelledby="headingSix" data-parent="#accordionExample">
+        <div class="card-body">
+            <p>GW ScholarSpace welcomes works in most digital formats; however, using <a href="https://scholarspace.library.gwu.edu/about?locale=en#preservation-formats">recommended preservation formats</a> will facilitate long-term preservation and usability.</p>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingSeven" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven"> What do I need to do before submitting my work to GW ScholarSpace? </button></h3>
+    </div>
+    <div id="collapseSeven" class="collapse" aria-labelledby="headingSeven" data-parent="#accordionExample">
+        <div class="card-body">
+            <p>You must read and agree to the <a href="https://scholarspace.library.gwu.edu/terms">Terms of Use</a> and terms of the <a href="https://scholarspace.library.gwu.edu/agreement">Deposit Agreement</a> in order to submit your works.</p>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div id="headingEight" class="card-header">
+        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight"> What is a Creative Commons license? </button></h3>
+    </div>
+    <div id="collapseEight" class="collapse" aria-labelledby="headingEight" data-parent="#accordionExample">
+        <div class="card-body">
+            <p>GW ScholarSpace allows copyright holders to apply specific creative commons licenses to their works. For more information on Creative Commons, please see the <a href="https://creativecommons.org/">Creative Commons official website</a>.</p>
+        </div>
+    </div>
+</div>
+</div>
+
+<h2>GW ScholarSpace ETDs</h2>
+<p>As the George Washington University's institutional repository for electronic theses and dissertations (ETDs), GW ScholarSpace provides free, public access, broad visibility, and long-term preservation for ETDs created by GW's students.</p>
+<p>The following information is specific to ETDs in GW ScholarSpace.</p>
+
+<div id="accordionETD" class="accordion">  
+    <div class="card">
+        <div id="ETDheadingOne" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#ETDcollapseOne" aria-expanded="false" aria-controls="ETDcollapseOne"> Will my thesis/dissertation be publicly discoverable? </button></h3>
+        </div>
+        <div id="ETDcollapseOne" class="collapse" aria-labelledby="ETDheadingOne" data-parent="#accordionETD">
+            <div class="card-body">
+                <p>Yes, GW ScholarSpace is intended for public access. However, if your publisher requires a temporary embargo, we can facilitate that (see <a href="https://scholarspace.library.gwu.edu/about?locale=en#embargoes">Embargoes</a> for general and ETD-specific information).</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div id="ETDheadingTwo" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#ETDcollapseTwo" aria-expanded="false" aria-controls="ETDcollapseTwo"> What kinds of ETD materials may not be in the GW ScholarSpace repository? </button></h3>
+        </div>
+        <div id="ETDcollapseTwo" class="collapse" aria-labelledby="ETDheadingTwo" data-parent="#accordionETD">
+            <div class="card-body">
+                <p>GW ScholarSpace is not appropriate for ETDs or supplementary files that include sensitive data such as personally identifiable information (PII) or protected health information (PHI).</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div id="ETDheadingThree" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#ETDcollapseThree" aria-expanded="false" aria-controls="ETDcollapseThree"> What file formats are accepted in GW ScholarSpace? </button></h3>
+        </div>
+        <div id="ETDcollapseThree" class="collapse" aria-labelledby="ETDheadingThree" data-parent="#accordionETD">
+            <div class="card-body">
+                <p>GW ScholarSpace welcomes works in most digital formats; however, using <a href="https://scholarspace.library.gwu.edu/about?locale=en#preservation-formats">recommended preservation formats</a> will facilitate long-term preservation and usability. These recommendations apply to ETD and non-ETD works alike.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<h2>Using GW ScholarSpace to comply with GW's Open Access Resolution</h2>
+<p>The Open Access Resolution automatically gives GW a non-exclusive right to distribute the works, unless an opt-out waiver has been signed (see <a href="http://library.gwu.edu/about/open-access-faqs#Opting%20Out">Opting Out</a>). When signing publishing agreements for the publication of an article, the author(s) should let the publisher know that the agreement is subject to prior license agreement with The George Washington University. The <a href="https://library.gwu.edu/sites/default/files/communications/AuthorsAddendum17Dec2014.pdf">Author's Addendum</a> can be found at <a href="http://library.gwu.edu/open-access/">Open Access at GW</a>.</p>
+<p>As soon as an article is published, you will be able to upload a copy directly into the GW ScholarSpace repository. Currently, you may submit your work through our Deposit Form and the Library will notify you when the work has been uploaded.</p>
+
+<h2>Depositing your works</h2>
+<div id="accordionDep" class="accordion">  
+    <div class="card">
+        <div id="DepheadingOne" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseOne" aria-expanded="false" aria-controls="DepcollapseOne"> Where do I go to deposit my works to GW ScholarSpace? </button></h3>
+        </div>
+        <div id="DepcollapseOne" class="collapse" aria-labelledby="DepheadingOne" data-parent="#accordionDep">
+            <div class="card-body">
+                <p>To deposit your ETD, please start by visiting <a href="https://library.gwu.edu/etd">the library's ETD page</a>.</p>
+                <p>To deposit any other type of work, please use the <a href="https://library.gwu.edu/scholarspace/submit/">GW ScholarSpace Deposit Form</a>.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div id="DepheadingTwo" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseTwo" aria-expanded="false" aria-controls="DepcollapseTwo"> What is the maximum size of files that can be uploaded to GW ScholarSpace? </button></h3>
+        </div>
+        <div id="DepcollapseTwo" class="collapse" aria-labelledby="DepheadingTwo" data-parent="#accordionDep">
+            <div class="card-body">
+                <p>For non-ETD works, GW ScholarSpace has an upload size limit of 25 MB. If you would like to upload multiple files or a file larger than 25 MB for a non-ETD work, please send an email to <a href="mailto:scholarspace@gwu.edu">scholarspace@gwu.edu</a>. For all information regarding ETD deposits, please start by visiting <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a>.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div id="DepheadingThree" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseThree" aria-expanded="false" aria-controls="DepcollapseThree"> Do I need to fill in all of the fields on the deposit form when submitting my work? </button></h3>
+        </div>
+        <div id="DepcollapseThree" class="collapse" aria-labelledby="DepheadingThree" data-parent="#accordionDep">
+            <div class="card-body">
+                <p>For non-ETD works, you, or a designated depositor, will need to fill in the required fields on the deposit form and accept the Deposit Agreement before being able to submit your work; however, if you can provide more information about your work in the optional fields provided, it will increase the discoverability of your work within GW ScholarSpace. For all information regarding ETD deposits, please start by visiting <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a>.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<h2>Visibility and Sharing</h2>
+<p>Works deposited to GW ScholarSpace are publicly discoverable except where embargoed.</p>
+
+<h2 id="embargoes">Embargoes</h2>
+<p>Works deposited to GW ScholarSpace may be embargoed for a limited period if required by the publisher (see <a href="http://library.gwu.edu/about/faculty-open-access">Open Access Resolution</a>).</p>
+<p>If a work is embargoed, only the files will be embargoed and hidden from public view; the work's metadata such as title, abstract, author, advisor, etc. is public. Please visit <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a> for more information on embargoes of ETDs.</p>
+
+<h2>Preservation</h2>
+<p>GWLAI is committed to providing long-term access to all works submitted to GW ScholarSpace. Informed by best practices, GW ScholarSpace and GW Libraries staff use digital preservation strategies that adapt to the changing technological environment.</p>
+<p>For more detailed information about the levels of preservation offered by GW Libraries, please see the <a href="https://library.gwu.edu/digital-stewardship-services">Digital Stewardship Service Catalog</a>. GW ScholarSpace material receives <strong>Tier 1</strong> support.</p>
+<div id="accordionPres" class="accordion">  
+    <div class="card">
+        <div id="PresheadingOne" class="card-header">
+            <h3 class="mb-0" id="preservation-formats"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#PrescollapseOne" aria-expanded="false" aria-controls="PrescollapseOne"> What are recommended preservation formats? </button></h3>
+        </div>
+        <div id="PrescollapseOne" class="collapse" aria-labelledby="PresheadingOne" data-parent="#accordionPres">
+            <div class="card-body">
+                <p>Recommended preservation formats have been accepted by information technology, archival, and records management professional communities due to multiple factors such as: format longevity, acceptance and use in professional communities, long term accessibility of most viewing software, and incorporated metadata. For more information about digital preservation best practices and standards, please see the Library of Congress <a href="http://www.loc.gov/preservation/resources/rfs/TOC.html">Recommended Formats Statement</a>.</p>
+                <table border="1" width="496" cellspacing="5px" cellpadding="5px">
+                    <thead>
+                    <tr style="text-align: center;">
+                    <td style="padding: 7px;"><strong>Type</strong></td>
+                    <td style="padding: 7px;"><strong>Recommended Preservation Format</strong></td>
+                    <td style="padding: 7px;"><strong>File Extension</strong></td>
+                    </tr>
+                    </thead>
+                        <tbody>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Text</td>
+                                <td style="padding: 7px;">PDF/A or PDF</td>
+                                <td style="padding: 7px; text-align: center;">.pdf</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Text</td>
+                                <td style="padding: 7px;">Plain Text</td>
+                                <td style="padding: 7px; text-align: center;">.txt</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Text</td>
+                                <td style="padding: 7px;">XML</td>
+                                <td style="padding: 7px; text-align: center;">.xml</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Text</td>
+                                <td style="padding: 7px;">CSV</td>
+                                <td style="padding: 7px; text-align: center;">.csv</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Image</td>
+                                <td style="padding: 7px;">JPEG</td>
+                                <td style="padding: 7px; text-align: center;">.jpg</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Image</td>
+                                <td style="padding: 7px;">TIFF</td>
+                                <td style="padding: 7px; text-align: center;">.tif</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 7px; text-align: center;">Audio</td>
+                                <td style="padding: 7px;">Broadcast Wave</td>
+                                <td style="padding: 7px; text-align: center;">.wav</td>
+                            </tr>
+                        </tbody>
+                    </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<h2>Withdrawal</h2>
+<p>Works submitted to GW ScholarSpace are permanent. Under certain circumstances a work in GW ScholarSpace may be removed from view (e.g. due to a violation of the GW ScholarSpace Deposit Agreement). To avoid loss of the historical record, all such instances will be documented via a statement attached to the record in PDF. The content of the document should be: “This work has been withdrawn from GW ScholarSpace. If you have questions, please contact __________.”</p>
+
+<h2>Related University Policies</h2>
+<p><a href="http://library.gwu.edu/about/faculty-open-access/">GW Faculty Open Access Resolution</a></p>
+<p><a href="http://my.gwu.edu/files/policies/CopyrightPolicyFINAL.pdf">GW Copyright Policy</a></p>
+<p><a href="http://my.gwu.edu/files/policies/PublicAccessNIHPublicationsPolicyFINAL.pdf">GW Public Access NIH Publications Policy</a></p>
+<p><a href="http://my.gwu.edu/files/policies/RecordManagementFINAL.pdf">GW Records Management Policy</a></p>
+<p><a href="https://commercialization.gwu.edu/gw-policies">GW Technology Commercialization Office Transfer Policies</a></p>
+<p><a href="http://my.gwu.edu/files/policies/InformationSecurityPolicyFINAL.pdf">GW Information Security Policy</a></p>

--- a/spec/fixtures/content_blocks/featured_researcher.html
+++ b/spec/fixtures/content_blocks/featured_researcher.html
@@ -1,0 +1,3 @@
+<h2><img style="margin: 0px 10px 10px 0px;" src="https://scholarspace.library.gwu.edu/gwur.png" alt="GW Undergraduate Review" />The George Washington University ​Undergraduate Review</h2>
+<p>Established in 2016, the GW Undergraduate Review (GWUR) is the premier publication of research from undergraduate students at George Washington University. Its mission is to promote undergraduate research on GW&rsquo;s campus through events, workshops, and the annual publication of a peer-reviewed journal. GWUR is entirely student-run and is supported by the Office of the Vice Provost for Research and GW Libraries and Academic Innovation.</p>
+<p><a class="gw-btn" href="https://scholarspace.library.gwu.edu/collections/rb68xc712?locale=en">Browse all content from GWUR</a></p>

--- a/spec/fixtures/content_blocks/help_page.html
+++ b/spec/fixtures/content_blocks/help_page.html
@@ -1,0 +1,39 @@
+<h1>Help</h1>
+
+<h2>User Support</h2>
+<p>If you need to report a problem using GW ScholarSpace or would like to request service assistance, consultation, or share feedback, please submit your issue via the <a href="https://scholarspace.library.gwu.edu/contact">Contact Form</a>.</p>
+<p>System Maintenance Hours: To keep systems running at peak performance, and to ensure the best possible service, routine testing and maintenance are performed during the daily maintenance window from 5:00 a.m. to 7:00 a.m. EST/EDT. During this time, systems and services may be affected.</p>
+
+<h2>Browse</h2>
+<p>From the main page of GW ScholarSpace, you can browse using the &#128270; button.</p>
+
+<h2>Search</h2>
+<p>GW ScholarSpace allows you to conduct a Basic or faceted Search of its works. You may conduct a Basic Search using the search bar.</p>
+
+<h2>Deposit</h2>
+<div id="accordionDep" class="accordion">  
+    <div class="card">
+        <div id="DepheadingOne" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseOne" aria-expanded="false" aria-controls="DepcollapseOne"> For works other than Electronic Theses and Dissertations: </button></h3>
+        </div>
+        <div id="DepcollapseOne" class="collapse" aria-labelledby="DepheadingOne" data-parent="#accordionDep">
+            <div class="card-body">
+                <p>Please use the <a href="http://library.gwu.edu/scholarspace/submit">Deposit Form</a> to submit your works to GW Scholarspace.</p>
+                <p>The form requires you to read and agree to the terms of the <a href="https://scholarspace.library.gwu.edu/agreement">Deposit Agreement</a> in order to submit your works. Once you have reviewed these terms, check the box and continue with the rest of the form.</p>
+                <p>After submitting the form, you will receive an automatic email response confirmation to acknowledge that your works were successfully submitted. You will receive another notification email when your works become viewable in GW ScholarSpace.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div id="DepheadingTwo" class="card-header">
+            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseTwo" aria-expanded="false" aria-controls="DepcollapseTwo"> For information about uploading your electronic thesis or dissertation: </button></h3>
+        </div>
+        <div id="DepcollapseTwo" class="collapse" aria-labelledby="DepheadingTwo" data-parent="#accordionDep">
+            <div class="card-body">
+                <p>Please see <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a>.</p>
+                <p>If you any questions about this process or are having problems, please <a href="https://scholarspace.library.gwu.edu/contact">contact us</a>.</p>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This is just the CSS/SCSS for the accordion implementation on the various pages that need them, but as the HTML was changed elsewhere, it should fix #419.

The accordions do a little animation jump when they finish expanding (I am familiar with this issue...), so if you review and it is distracting, feel free to request changes and I'll dig into it.