### PR TITLE
T412 Dashboard breadcrumbs

### DIFF
--- a/app/assets/stylesheets/scholarspace/components/_collection.scss
+++ b/app/assets/stylesheets/scholarspace/components/_collection.scss
@@ -49,7 +49,7 @@
             width: 100%;
             border-radius: 0;
             padding: 0.4rem;
-            margin-left: 0.3rem;
+            margin-left: 0;
         
               .glyphicon-search::before {
                 font-size: 1rem;

--- a/app/assets/stylesheets/scholarspace/components/_collection.scss
+++ b/app/assets/stylesheets/scholarspace/components/_collection.scss
@@ -45,14 +45,17 @@
           margin-top: 1rem;
           width: 100%;
   
-          .btn {
+          .btn, #collection_submit {
             width: 100%;
             border-radius: 0;
-            border: 1px solid $gw-dark-grey;
-            background-color: #EFEFEF;
-            color: $gw-dark-grey;
+            padding: 0.4rem;
+            margin-left: 0.3rem;
+        
+              .glyphicon-search::before {
+                font-size: 1rem;
+              }
+            }
           }
-        }
   
         @media (min-width: $mobile-breakpoint) {
           flex-direction: row;
@@ -63,7 +66,7 @@
   
             .btn {
               width: auto;
-              margin-left: 1em;
+              margin-left: 1rem;
             }
           }
         }

--- a/app/assets/stylesheets/scholarspace/components/_dashboard.scss
+++ b/app/assets/stylesheets/scholarspace/components/_dashboard.scss
@@ -13,14 +13,13 @@
 body.dashboard {
     padding-top: 7.8em;
     padding-top: 0;
+
+    .breadcrumb {
+      border-radius: 0;
+    }
   
     .main-content {
       padding-top: 1rem;
-  
-      // ideally will change this method to removing breadcrumbs on all controllers eventually
-      .breadcrumb {
-        display: none;
-      }
 
       div.sort-toggle {
         select, .view-type-group a {
@@ -120,6 +119,7 @@ body.dashboard {
       &:hover {
         background-color: transparent;
         text-decoration: underline;
+        border-color: transparent;
         border-top: 2px solid transparent;
         border-bottom: none;
       }
@@ -133,6 +133,7 @@ body.dashboard {
     .nav-tabs > li.active > a:hover {
       background-color: $gw-white;
       text-decoration: none;
+      border-color: #ddd;
       border-top: 1px solid #ddd;
       border-bottom: none;
     }


### PR DESCRIPTION
Will close #412.

Simply brought the dashboard breadcrumbs back. 

Also found an unticketed CSS bug on the individual collections page (can test at /collections/gwur) where the button was missing its magnifying glass, so added that in here for consolidating my many small PRs.