### PR TITLE
Add apply_contentblock_changes rake task

### DIFF
--- a/lib/tasks/gwss.rake
+++ b/lib/tasks/gwss.rake
@@ -290,4 +290,20 @@ namespace :gwss  do
   task reindex_everything: :environment do
     ActiveFedora::Base.reindex_everything
   end
+
+  desc "Apply ContentBlock changes"
+  task apply_contentblock_changes: :environment do
+    featured_researcher_html = File.open("#{Rails.root}/spec/fixtures/content_blocks/featured_researcher.html")
+    about_page_html = File.open("#{Rails.root}/spec/fixtures/content_blocks/about_page.html")
+    help_page_html = File.open("#{Rails.root}/spec/fixtures/content_blocks/help_page.html")
+
+    ContentBlock.find_or_create_by(name: "header_background_color").update!(value: "#FFFFFF")
+    ContentBlock.find_or_create_by(name: "header_text_color").update!(value: "#444444")
+    ContentBlock.find_or_create_by(name: "link_color").update!(value: "#28659A")
+    ContentBlock.find_or_create_by(name: "footer_link_color").update!(value: "#FFFFFF")
+    ContentBlock.find_or_create_by(name: "primary_buttom_background_color").update!(value: "#28659A")
+    ContentBlock.find_or_create_by(name: "featured_researcher").update!(value: featured_researcher_html.read)
+    ContentBlock.find_or_create_by(name: "about_page").update!(value: about_page_html.read)
+    ContentBlock.find_or_create_by(name: "help_page").update!(value: help_page_html.read)
+  end
 end


### PR DESCRIPTION
Will close #438 

Added a rake task, which can be run with `gwss:apply_contentblock_changes`, to apply the html for the about/help/featured researcher blocks and set the GW colors if not already applied. 

The steps that this rake task runs are already incorporated into the seed file for convenience in development, so this is for applying changes to an instance with existing data. 

To test:
 - If testing with seed 
   - comment out or delete everything from `# -- Styling and content blocks` to the end (circa line 277), then create and seed database. This creates a development instance with empty content blocks. 
   - Run `gwss:apply_contentblock_changes` to update the content blocks from the files stored in `spec/fixtures/content_blocks`
 - If testing with existing data, just run `gwss:apply_contentblock_changes` in the rails app.
 
If successful, will result in about page/help page/featured researcher block populated with content and accordion styling. 