### PR TITLE
t451 + t452 collections page and importers page style bug fixes

### DIFF
--- a/app/assets/stylesheets/scholarspace/components/_accordion.scss
+++ b/app/assets/stylesheets/scholarspace/components/_accordion.scss
@@ -1,7 +1,6 @@
 // Styling accordions on about & help to match GW conventions
-.collapse,
-.collapsing {
-  max-height: 50vh;
+.accordion-title {
+    font-weight: 400;
 }
 
 .accordion {

--- a/app/assets/stylesheets/scholarspace/components/_dashboard.scss
+++ b/app/assets/stylesheets/scholarspace/components/_dashboard.scss
@@ -123,6 +123,10 @@ body.dashboard {
         border-top: 2px solid transparent;
         border-bottom: none;
       }
+
+      &:focus {
+        background-color: transparent;
+      }
     }
 
     .nav-tabs > li {


### PR DESCRIPTION
Should close #451 and #452. Unset `max-height` on collapsable elements. I threw a couple minor relevant style fixes into this for the respective pages that I found while testing, such as label `font-weight` and link focus `background-color`. 