### PR TITLE
fixed link in featured html block (unticketed)

### DIFF
--- a/spec/fixtures/content_blocks/featured_researcher.html
+++ b/spec/fixtures/content_blocks/featured_researcher.html
@@ -1,3 +1,3 @@
 <h2><img class="featured" src="https://scholarspace.library.gwu.edu/gwur.png" alt="GW Undergraduate Review" />The George Washington University ​Undergraduate Review</h2>
 <p>Established in 2016, the GW Undergraduate Review (GWUR) is the premier publication of research from undergraduate students at George Washington University. Its mission is to promote undergraduate research on GW&rsquo;s campus through events, workshops, and the annual publication of a peer-reviewed journal. GWUR is entirely student-run and is supported by the Office of the Vice Provost for Research and GW Libraries and Academic Innovation.</p>
-<p><a class="gw-btn" href="https://scholarspace.library.gwu.edu/collections/rb68xc712?locale=en">Browse all content from GWUR</a></p>
+<p><a class="gw-btn" href="collections/gwur">Browse all content from GWUR</a></p>


### PR DESCRIPTION
I had a thought about Monday's user testing: It's likely users will try the "browse all from GWUR" button for some of the prompts, which would bring them to production. I changed the HTML a bit to keep everything on the same domain. Best practices anyway!