### PR TITLE
Add admin authentication for sidekiq dashboard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,8 +43,11 @@ Rails.application.routes.draw do
   end
 
   require 'sidekiq/web'
-  mount Sidekiq::Web => '/sidekiq'
-
+  
+  authenticate :user, lambda { |u| u.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+  
   match '*path', to: 'errors#not_found', via: :all, format: false, defaults: { format: 'html' }
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/features/sidekiq_dashboard_spec.rb
+++ b/spec/features/sidekiq_dashboard_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe "Sidekiq Dashboard Access" do
+
+  it 'loads sidekiq dashboard for a logged in admin user' do
+    admin_user = FactoryBot.create(:admin_user)
+
+    visit "/users/sign_in"
+
+    fill_in("user_email", with: admin_user.email)
+    fill_in("user_password", with: admin_user.password)
+    
+    click_button("Log in")
+
+    visit("/sidekiq")
+
+    expect(current_path).to eq("/sidekiq")
+  end
+
+  it 'redirects users to sign-in page if not logged in as admin' do
+    visit("/sidekiq")
+
+    expect(current_path).to eq("/users/sign_in")
+  end
+
+  it 'redirects to a 404 page if visited by logged in non-admin user' do
+    non_admin_user = FactoryBot.create(:user)
+
+    visit "/users/sign_in"
+
+    fill_in("user_email", with: non_admin_user.email)
+    fill_in("user_password", with: non_admin_user.password)
+    
+    click_button("Log in")
+
+    visit("/sidekiq")
+
+    expect(page).to have_content("404: Page not found")
+  end
+
+end


### PR DESCRIPTION
Fixes #483 and #354 

Tried on my development server, and this setup worked.

To test: 
- Deploy application
- When logged in as a user with the `admin` role - the sidekiq dashboard, accessible at `/sidekiq/`, should be visible. 
- When not logged in, or logged in as a non-admin, should redirect to the scholarspace login page. 