### PR TITLE
T482 - results with no keywords have incorrect fields

### DIFF
--- a/app/assets/stylesheets/scholarspace/components/_search.scss
+++ b/app/assets/stylesheets/scholarspace/components/_search.scss
@@ -82,6 +82,10 @@
       }
     }
   }
+
+  .dl-horizontal {
+    display: grid;
+  }
   
   .panel-group .panel + .panel {
     margin-top: 0;

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -4,8 +4,10 @@
     <% doc_presenter = index_presenter(document) %>
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
+        <div>
           <dt><%= render_index_field_label document, field: field_name %></dt>
           <dd><%= doc_presenter.field_value field_name %></dd>
+        </div>
       <% end %>
     <% end %>
     </dl>


### PR DESCRIPTION
Fixes #482 - Wraps each word/definition pair in definition list in generic div, sets up results as grids