### PR TITLE
T461 sitemap setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ a separate user for the app, but it is not necessary.  That user will need to ow
     - `--create-roles`: create default app roles (if they don't already exist)
     - `--create-admin-set`: create the default Admin Set, if it doesn't already exist
     - `--add-admin-user`: grant a ScholarSpace user the `admin` role. To use: first, create the user in the ScholarSpace UI. Then run this command, inserting an environment variable (`admin_user=USER_EMAIL_ADDRESS`) before the path to the script. This environment variable will be used by the Rake task to look up the user in the app database. 
-21. To generate a sitemap, run `docker exec -it --user scholarspace [sidekiq-container-name] bash -lc "docker/scripts/app-init.sh --create-sitemap"`. **This command should be run in the Sidekiq container**, not the app server container.
+21. To start the job to generate a sitemap, run `docker exec -it --user scholarspace [app-container-name] bash -lc "docker/scripts/app-init.sh --create-sitemap"`. With default configurations, this job will run every morning at 12:30 AM, or can be configured in `config/schedule.rb` to run on a different schedule.
 
 ## Redeployment
 

--- a/docker/scripts/scholarspace-setup.sh
+++ b/docker/scripts/scholarspace-setup.sh
@@ -11,7 +11,7 @@ groupadd -r scholarspace --gid=${SCHOLARSPACE_GID:-999} \
 
 # Create the log file here, so that it will be created with the correct permissions
 # Otherwise, Passenger will create it as root
-setuser scholarspace touch /opt/scholarspace/scholarspace-hyrax/log/${RAILS_ENV}.log
+setuser scholarspace touch /opt/scholarspace/scholarspace-hyrax/log/production.log
 
 # Set up nginx configuration, applying environment variables
 echo "Configuring nginx"
@@ -28,27 +28,18 @@ rm /etc/nginx/sites-enabled/default
 # Not sure if this step is necessary  
 setuser scholarspace ruby2.7 -S passenger-config build-native-support
 
-./docker/scripts/hyrax-config.sh
-
-if [[ "$#" -eq 1 && $1 = "sidekiq" ]]
-then  
-  # Create sitemap cronjob, if necessary
-  setuser scholarspace crontab -l > cron.tmp
-  # cron.tmp won't be created if not cron jobs exist
-  # if cron job exists, presume we've already created the sitemap job
-  if [[ ! -e cron.tmp || ! -s cron.tmp ]]
-  then
-    # This isn't working in the docker volume, not sure why. It seems unable to execute the bundle command.
-    echo "Creating cron job for sitemap"
-    setuser scholarspace bundle exec whenever > cron.tmp && setuser scholarspace crontab cron.tmp
-    rm cron.tmp
-  fi
+if [[ "$#" -eq 1 && $1 = "sidekiq" ]]; then  
   echo "Starting sidekiq"
-  exec /sbin/my_init -- bash -lc "bundle exec sidekiq"
-fi
+  exec /sbin/my_init -- bash -lc "bundle exec sidekiq --environment production"
+else
 
+# Setting up sitemap regeneration schedule - configure in config/schedule.rb
+# Default configuration is every day at 12:30 AM
+echo "Preparing sitemap crontab"
+setuser scholarspace bundle exec whenever --update-crontab
 
 echo "Starting Passenger..."
 # Enable Nginx
 rm -f /etc/service/nginx/down
 exec /sbin/my_init
+fi

--- a/docker/scripts/scholarspace-setup.sh
+++ b/docker/scripts/scholarspace-setup.sh
@@ -28,6 +28,8 @@ rm /etc/nginx/sites-enabled/default
 # Not sure if this step is necessary  
 setuser scholarspace ruby2.7 -S passenger-config build-native-support
 
+./docker/scripts/hyrax-config.sh
+
 if [[ "$#" -eq 1 && $1 = "sidekiq" ]]; then  
   echo "Starting sidekiq"
   exec /sbin/my_init -- bash -lc "bundle exec sidekiq --environment production"

--- a/spec/features/schedule_spec.rb
+++ b/spec/features/schedule_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'whenever'
+
+RSpec.describe "Schedule crontab" do
+
+  it 'generates crontab to run sitemap generate job at 12:30 am' do
+    expected = "30 0 * * * /bin/bash -l -c 'cd /opt/scholarspace/scholarspace-hyrax && RAILS_ENV=test bundle exec rake gwss:sitemap_queue_generate --silent'"
+    actual = Whenever::JobList.new(file: Rails.root.join("config", "schedule.rb").to_s).generate_cron_output.strip
+
+    expect(actual).to eq(expected)
+  end
+
+end


### PR DESCRIPTION
Will close #461 

Main changes here:
1. Changing the process for generating sitemap to use `bundle exec whenever --update-crontab`. I believe that not including the `--update-crontab`  was the reason it was initially generating the sitemap, because it didn't seem to update the crontab file without that argument. 
2. Moving the command for generating the crontab to the main app container, rather than Sidekiq, and then letting the main rails container delegate it to Sidekiq. Unless there's a benefit to running it directly on Sidekiq that I'm not aware of, running it directly on the app and having ActiveJob do the delegating works and seems simpler. 
3. Add spec test for `schedule.rb`. This is really only testing that the output from `bundle exec whenever --update-crontab` matches what we would expect for running daily at 12:30 AM - but does not whether or not it runs. 

I tested this by: 
- Modified the `schedule.rb` file to configure the first SitemapRegenerateJob to run every 20 minutes.
- Created Docker containers, and then restored prod backup data following steps in README.
- Verified that there was no `public/sitemap.xml` present initially.
- Waited until the job triggered on the 20 minute mark, waited until that finished, then verified that it created the `public/sitemap.xml` and the `public/sitemaps/sitemap-fragment-1.xml` and `public/sitemaps/sitemap-fragment-2.xml` files. 

To test - you could follow a similar process, or setup a new instance, verify the sitemap files are not present, and check again after the job is schedule to run - so the next day. 

![Screen Shot 2024-01-18 at 3 59 48 PM](https://github.com/gwu-libraries/scholarspace-hyrax/assets/17027357/e607c4d4-2652-431f-a708-632fe696a694)
