### PR TITLE
T391 RSpec and associated testing gems

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--color
+--format documentation

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -1,0 +1,27 @@
+# from https://github.com/samvera/hyrax/blob/v2.9.6/spec/factories/admin_sets.rb
+
+FactoryBot.define do
+  factory :admin_set do
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    # Given the relationship between permission template and admin set, when
+    # an admin set is created via a factory, I believe it is appropriate to go ahead and
+    # create the corresponding permission template
+    #
+    # This way, we can go ahead
+    after(:create) do |admin_set, evaluator|
+      if evaluator.with_permission_template
+        attributes = { source_id: admin_set.id }
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        # There is a unique constraint on permission_templates.source_id; I don't want to
+        # create a permission template if one already exists for this admin_set
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: admin_set.id)
+      end
+    end
+
+    transient do
+      # false, true, or Hash with keys for permission_template
+      with_permission_template { false }
+    end
+  end
+end

--- a/spec/factories/gw_works.rb
+++ b/spec/factories/gw_works.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :gw_work do
+    id { Noid::Rails::Service.new.mint }
+    title { [Faker::Book.title] }
+    visibility { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  end
+end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+# From https://github.com/samvera/hyrax/blob/v2.9.6/spec/factories/permission_templates.rb
+FactoryBot.define do
+  factory :permission_template, class: Hyrax::PermissionTemplate do
+    # Given that there is a one to one strong relation between permission_template and admin_set,
+    # with a unique index on the source_id, I don't want to have duplication in source_id
+    sequence(:source_id) { |n| format('%010d', n) }
+
+    before(:create) do |permission_template, evaluator|
+      if evaluator.with_admin_set
+        source_id = permission_template.source_id
+        admin_set =
+          if source_id.present?
+            begin
+              AdminSet.find(source_id)
+            rescue ActiveFedora::ObjectNotFoundError
+              create(:admin_set, id: source_id)
+            end
+          else
+            create(:admin_set)
+          end
+        permission_template.source_id = admin_set.id
+      elsif evaluator.with_collection
+        source_id = permission_template.source_id
+        collection =
+          if source_id.present?
+            begin
+              Collection.find(source_id)
+            rescue ActiveFedora::ObjectNotFoundError
+              create(:collection, id: source_id)
+            end
+          else
+            create(:collection)
+          end
+        permission_template.source_id = collection.id
+      end
+    end
+
+    after(:create) do |permission_template, evaluator|
+      if evaluator.with_workflows
+        Hyrax::Workflow::WorkflowImporter.load_workflow_for(permission_template: permission_template)
+        Sipity::Workflow.activate!(permission_template: permission_template, workflow_id: permission_template.available_workflows.pluck(:id).first)
+      end
+      if evaluator.with_active_workflow
+        workflow = create(:workflow, active: true, permission_template: permission_template)
+        create(:workflow_action, workflow: workflow) # Need to create a single action that can be taken
+      end
+      AccessHelper.create_access(permission_template, 'user', :manage, evaluator.manage_users) if evaluator.manage_users.present?
+      AccessHelper.create_access(permission_template, 'group', :manage, evaluator.manage_groups) if evaluator.manage_groups.present?
+      AccessHelper.create_access(permission_template, 'user', :deposit, evaluator.deposit_users) if evaluator.deposit_users.present?
+      AccessHelper.create_access(permission_template, 'group', :deposit, evaluator.deposit_groups) if evaluator.deposit_groups.present?
+      AccessHelper.create_access(permission_template, 'user', :view, evaluator.view_users) if evaluator.view_users.present?
+      AccessHelper.create_access(permission_template, 'group', :view, evaluator.view_groups) if evaluator.view_groups.present?
+    end
+
+    transient do
+      with_admin_set { false }
+      with_collection { false }
+      with_workflows { false }
+      with_active_workflow { false }
+      manage_users { nil }
+      manage_groups { nil }
+      deposit_users { nil }
+      deposit_groups { nil }
+      view_users { nil }
+      view_groups { nil }
+    end
+  end
+
+  factory :permission_template_access, class: Hyrax::PermissionTemplateAccess do
+    permission_template
+    trait :manage do
+      access { 'manage' }
+    end
+
+    trait :deposit do
+      access { 'deposit' }
+    end
+
+    trait :view do
+      access { 'view' }
+    end
+  end
+
+  # rubocop:disable Lint/ConstantDefinitionInBlock
+  class AccessHelper
+    def self.create_access(permission_template_id, agent_type, access, agent_ids)
+      agent_ids.each do |agent_id|
+        FactoryBot.create(:permission_template_access,
+                          access,
+                          permission_template: permission_template_id,
+                          agent_type: agent_type,
+                          agent_id: agent_id)
+      end
+    end
+  end
+  # rubocop:enable Lint/ConstantDefinitionInBlock
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :user do
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+
+    factory :admin_user do
+      after :create do |user|
+        admin_role = Role.find_or_create_by(name: 'admin')
+        admin_role.users << user
+      end
+    end
+
+    factory :content_admin_user do
+      after :create do |user|
+        content_admin_role = Role.find_or_create_by(name: 'content-admin')
+        content_admin_role.users << user
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require_relative "../spec/support/database_cleaner"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,10 +13,18 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'capybara/rspec'
+require 'simplecov'
+SimpleCov.start 'rails'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+
+  config.backtrace_exclusion_patterns = []
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,19 @@
+RSpec.configure do |config|
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with :truncation, except: %w(ar_internal_metadata)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
+end


### PR DESCRIPTION
# PR 2 of 3 for automated test and CI/CD

This PR is focused on the configuration of testing suite tools, including:
- RSpec
- FactoryBot
- SimpleCov
- DatabaseCleaner

## To test:

- Build and start Docker containers
- Start interactive terminal in the app-server container, e.g. `docker exec -it scholarspace-hyrax_app-server_1 /bin/sh`
- Change to `scholarspace` user with `su scholarspace`
- Create dev/test databases with `bundle exec rails db:create`
- Migrate dev/test databases with `bundle exec rails db:migrate`
- Run `bundle exec rspec`

You should see 17 examples, 2 failing tests, 12 pending tests, and 3 passing tests. PRs for additional rspec tests configured for this setup will follow this one. 

To note, you will see _a lot_ of deprecation errors mixed in with the output. These primarily come from the Hyrax 3.6.0 gem, and figuring out what can/should be updated vs. silenced (as well as how to actually get these silenced) is another issue.

<img width="483" alt="image" src="https://github.com/gwu-libraries/scholarspace-hyrax/assets/17027357/0d2cfca5-2fca-4ca5-b51d-4636b3d991ed">