### PR TITLE
Fixes #500 - resolves passenger version mismatch error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# When upgrading passenger-ruby image version, make sure to update passenger version in Gemfile
 FROM phusion/passenger-ruby27:2.5.0
 
 LABEL org.opencontainers.image.source=https://github.com/gwu-libraries/scholarspace-hyrax

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ gem 'pg'
 # See https://github.com/viseztrance/rails-sitemap
 gem 'sitemap'
 # Use Passenger as the app server
-gem "passenger", ">= 5.3.2", require: "phusion_passenger/rack_handler"
+# Update this when we update the Passenger docker container base image version
+gem 'passenger', "~> 6.0.17", require: "phusion_passenger/rack_handler"
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'pg'
 gem 'sitemap'
 # Use Passenger as the app server
 # Update this when we update the Passenger docker container base image version
-gem 'passenger', "~> 6.0.17", require: "phusion_passenger/rack_handler"
+gem 'passenger', '6.0.17', require: "phusion_passenger/rack_handler"
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -674,7 +674,7 @@ GEM
     orm_adapter (0.5.0)
     os (1.1.4)
     parslet (2.0.0)
-    passenger (6.0.20)
+    passenger (6.0.17)
       rack
       rake (>= 0.8.1)
     pg (1.5.3)
@@ -1037,7 +1037,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_racer
   orderly
-  passenger (~> 6.0.17)
+  passenger (= 6.0.17)
   pg
   rails (~> 5.2.8.1)
   recaptcha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -674,7 +674,7 @@ GEM
     orm_adapter (0.5.0)
     os (1.1.4)
     parslet (2.0.0)
-    passenger (6.0.19)
+    passenger (6.0.20)
       rack
       rake (>= 0.8.1)
     pg (1.5.3)
@@ -1037,7 +1037,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_racer
   orderly
-  passenger (>= 5.3.2)
+  passenger (~> 6.0.17)
   pg
   rails (~> 5.2.8.1)
   recaptcha


### PR DESCRIPTION
To test, build app container and observe that commands such as `bundle exec rails c`, `bundle exec rspec`, or running rake tasks no longer result in errors related to a specific passenger gem version being not installed.