### PR TITLE
T475 & T503 update navbar and static pages

### DIFF
--- a/app/assets/stylesheets/scholarspace/base/_base.scss
+++ b/app/assets/stylesheets/scholarspace/base/_base.scss
@@ -68,6 +68,8 @@ html {
   }
 
   div.section-gw-white {
+    min-height: auto;
+    
     .gw-white-content {
       padding: 1.5em 0 0 0;
       

--- a/app/assets/stylesheets/scholarspace/components/_header.scss
+++ b/app/assets/stylesheets/scholarspace/components/_header.scss
@@ -1,6 +1,9 @@
 // navbar and header styling
 
 header {
+  height: 20px;
+  background-color: $gw-light-blue;
+
     #masthead {
       height: 100%;
       display: flex;
@@ -13,11 +16,16 @@ header {
       height: auto;
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: end;
     }
   
     @media (min-width: $mobile-breakpoint) {
       height: 7.8em;
+      background-color: transparent;
+
+      .container-fluid {
+        justify-content: space-between;
+      }
     }
 }
   
@@ -81,7 +89,7 @@ header {
   }
   
   .navbar-inverse {
-    background-color: $gw-dark-blue !important;
+    background-color: transparent !important;
     border-color: transparent;
   
     @media (min-width: $mobile-breakpoint) {
@@ -158,9 +166,10 @@ header {
             align-items: center;
   
             #mobile-title {
+              font-size: 2.5em;
+              font-weight: bold;
               margin-left: 0.3rem;
               color: $gw-white;
-              text-decoration: underline;
   
               &:hover {
                 color: $gw-light-grey;
@@ -239,6 +248,11 @@ header {
           }
         }
       }
+
+      .active > a {
+        color: $gw-white;
+        background-color: unset;
+      }
   
       .open .dropdown-menu > li > a {
         color: $gw-white;
@@ -257,9 +271,14 @@ header {
   
     .searchbar-right {
       width: 90%;
+      margin: 0.5em 0;
   
       @media (min-width: $mobile-breakpoint) {
-        width: 60%;
+        width: 70%;
+      }
+
+      @media (min-width: 880px) {
+        width: 100%;
       }
   
       input, .dropdown-toggle {
@@ -291,6 +310,14 @@ header {
       .dropdown-menu > li > a {
         font-weight: 200;
       }
+
+      #search-form-header {
+        margin-top: 0;
+
+        .input-group {
+          margin-bottom: 0;
+        }
+      }
   
       #search-field-header {
         border-radius: 4px;
@@ -309,15 +336,11 @@ header {
     }
   }
   
-  .home_share_work {
-    margin: 0;
-  }
-  
   #user_utility_links {
     display: flex;
     flex-direction: row;
     margin-left: 1rem;
-    margin-top: 0.3em;
+    margin-top: 0;
     margin-right: 0;
   
     .dropdown a, .notify-number {
@@ -327,14 +350,6 @@ header {
       &:hover, &:focus {
         background-color: transparent;
         color: $gw-white;
-      }
-  
-      @media (min-width: $mobile-breakpoint) {
-        color: $gw-dark-grey;
-  
-        &:hover, &:focus {
-          color: $gw-dark-grey;
-        }
       }
     }
   
@@ -358,6 +373,18 @@ header {
       &:hover {
         color: $gw-white;
         background-color: $gw-light-blue;
+      }
+    }
+
+    @media (min-width: $mobile-breakpoint) {
+      margin-top: 0.3rem;
+
+      .dropdown a, .notify-number {
+        color: $gw-dark-grey;
+
+      &:hover, &:focus {
+        color: $gw-dark-grey;
+      }
       }
     }
   }

--- a/app/assets/stylesheets/scholarspace/components/_header.scss
+++ b/app/assets/stylesheets/scholarspace/components/_header.scss
@@ -252,6 +252,11 @@ header {
       .active > a {
         color: $gw-white;
         background-color: unset;
+
+        &:hover {
+          color: $gw-white;
+          background: $gw-light-blue;
+        }
       }
   
       .open .dropdown-menu > li > a {

--- a/app/assets/stylesheets/scholarspace/components/_static-page.scss
+++ b/app/assets/stylesheets/scholarspace/components/_static-page.scss
@@ -70,3 +70,21 @@
         font-size: 2.7em;
     }
 }
+
+//contact page
+#new_contact_form {
+    display: flex;
+    flex-direction: column;
+    align-items: end;
+  
+    .form-group {
+      margin-left: 0;
+      margin-right: 0;
+      width: 100%;
+    }
+  
+    input[type="submit"] {
+      margin-right: 15px;
+      width: 10em;
+    }
+  }

--- a/app/assets/stylesheets/scholarspace/components/_static-page.scss
+++ b/app/assets/stylesheets/scholarspace/components/_static-page.scss
@@ -47,3 +47,26 @@
     }
 }
 
+// About Page Styles
+.about-header-text {
+    margin-bottom: 0;
+    color: $gw-light-blue;
+    font-size: 6em;
+    font-weight: bold;
+
+    @media (max-width: 1200px) {
+        font-size: 5em;
+    }
+
+    @media (max-width: 991px) {
+        font-size: 4em;
+    }
+
+    @media (max-width: 748px) {
+        font-size: 3em;
+    }
+
+    @media (max-width: 535px) {
+        font-size: 2.7em;
+    }
+}

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -13,14 +13,14 @@
         </div>
       <div class="collapse navbar-collapse" id="top-navbar-collapse">
         <ul class="nav navbar-nav col-sm-5">
-          <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
-            <%= link_to t(:'hyrax.controls.terms'), hyrax.terms_path, aria: current_page?(hyrax.terms_path) ? {current: 'page'} : nil %></li>
           <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
             <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
-          <li <%= 'class=active' if current_page?(hyrax.help_path) %>>
-            <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
           <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
             <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+           <li <%= 'class=active' if current_page?(hyrax.share_path) %>>
+            <%= link_to t(:'hyrax.controls.share'), hyrax.share_path, aria: current_page?(hyrax.share_path) ? {current: 'page'} : nil %></li>
+          <li <%= 'class=active' if current_page?(main_app.search_catalog_path) %>>
+            <%= link_to t(:'hyrax.controls.browse'), main_app.search_catalog_path, aria: current_page?(main_app.search_catalog_path) ? {current: 'page'} : nil %></li>
          <!-- Commented out language selector for now 
          <li>
             <%= render 'shared/locale_picker' if available_translations.size > 1 %></li> -->

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -7,24 +7,6 @@
         <%= render '/logo' %>
       </div>
 
-      <div class="share-header">
-            <!-- share your work button display qualities -->
-  <div class="home_share_work row">
-    <div class="text-center">
-      <% if signed_in? %>
-        <%= link_to '#',
-          class: "gw-btn",
-          data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-          <i class="glyphicon glyphicon-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-        <% end %>
-      <% else %>
-        <%= link_to t('hyrax.upload_url'),
-          class: "gw-btn" do %>
-          <i class="glyphicon glyphicon-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
       <!-- toggle user util links, depending on sign in status-->
       <%= render '/user_util_links' %>
       </div>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <div id="content" class="col-md-9 col-md-push-3 col-sm-8 col-sm-push-4">
+      <%= render 'search_results' %>
+  </div>
+
+  <div id="sidebar" class="col-md-3 col-md-pull-9 col-sm-4 col-sm-pull-8">
+    <%= render 'search_sidebar' %>
+  </div>
+</container>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,42 +1,44 @@
-<% provide :page_title, @presenter.page_title %>
+<div class="container">
+  <% provide :page_title, @presenter.page_title %>
 
-<%= render 'shared/citations' %>
+  <%= render 'shared/citations' %>
 
-<div class="row work-type">
-  <div class="col-xs-12">
-    <%= render 'work_type', presenter: @presenter %>
-    <%= render 'show_actions', presenter: @presenter %>
-  </div>
-  <div class="col-xs-12">&nbsp;</div>
-  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <%= render 'work_title', presenter: @presenter %>
-      </div>
-      <div class="panel-body">
-        <div class="row">
-          <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.iiif_viewer? %>
-            <div class="col-sm-12">
-              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+  <div class="row work-type">
+    <div class="col-xs-12">
+      <%= render 'work_type', presenter: @presenter %>
+      <%= render 'show_actions', presenter: @presenter %>
+    </div>
+    <div class="col-xs-12">&nbsp;</div>
+    <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <%= render 'work_title', presenter: @presenter %>
+        </div>
+        <div class="panel-body">
+          <div class="row">
+            <%= render 'workflow_actions_widget', presenter: @presenter %>
+            <% if @presenter.iiif_viewer? %>
+              <div class="col-sm-12">
+                <%= render 'representative_media', presenter: @presenter, viewer: true %>
+              </div>
+            <% end %>
+            <div class="col-sm-3 text-center work-preview">
+              <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
+              <%= render 'citations', presenter: @presenter %>
+              <%= render 'social_media' %>
             </div>
-          <% end %>
-          <div class="col-sm-3 text-center work-preview">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
-            <%= render 'citations', presenter: @presenter %>
-            <%= render 'social_media' %>
-          </div>
-          <div class="col-sm-9">
-            <%= render 'work_description', presenter: @presenter %>
-            <%= render 'metadata', presenter: @presenter %>
-            <%= render 'note_to_authors', presenter: @presenter %>
-          </div>
-          <div class="col-sm-12">
-            <%= render 'relationships', presenter: @presenter %>
-            <%= render 'items', presenter: @presenter %>
-            <%# TODO: we may consider adding these partials in the future %>
-            <%# = render 'sharing_with', presenter: @presenter %>
-            <%# = render 'user_activity', presenter: @presenter %>
+            <div class="col-sm-9">
+              <%= render 'work_description', presenter: @presenter %>
+              <%= render 'metadata', presenter: @presenter %>
+              <%= render 'note_to_authors', presenter: @presenter %>
+            </div>
+            <div class="col-sm-12">
+              <%= render 'relationships', presenter: @presenter %>
+              <%= render 'items', presenter: @presenter %>
+              <%# TODO: we may consider adding these partials in the future %>
+              <%# = render 'sharing_with', presenter: @presenter %>
+              <%# = render 'user_activity', presenter: @presenter %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,110 +1,111 @@
-<% provide :page_title, construct_page_title(@presenter.title) %>
-<div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
-  <div class="row hyc-header">
-    <div class="col-md-12">
-        <div class="hyc-generic">
-            <div class="hyc-wrap">
-                <% unless @presenter.logo_record.blank? %>
-                    <div class="hyc-logos">
-                <% @presenter.logo_record.each_with_index  do |lr, i| %>
+<div class="container">
+  <% provide :page_title, construct_page_title(@presenter.title) %>
+  <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
+    <div class="row hyc-header">
+      <div class="col-md-12">
+          <div class="hyc-generic">
+              <div class="hyc-wrap">
+                  <% unless @presenter.logo_record.blank? %>
+                      <div class="hyc-logos">
+                  <% @presenter.logo_record.each_with_index  do |lr, i| %>
 
-                    <% if lr[:linkurl].blank? %>
-                        <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
-                    <% else %>
-                        <a href="<%= lr[:linkurl] %>">
-                        <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
-                        </a>
-                    <% end %>
-                <% end %>
-                    </div>
-                <% end %>
-                <div class="hyc-title">
-                    <h1><%= @presenter.title.first %></h1>
-                    <%= @presenter.collection_type_badge %>
-                    <%= @presenter.permission_badge %>
-                </div>
+                      <% if lr[:linkurl].blank? %>
+                          <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
+                      <% else %>
+                          <a href="<%= lr[:linkurl] %>">
+                          <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
+                          </a>
+                      <% end %>
+                  <% end %>
+                      </div>
+                  <% end %>
+                  <div class="hyc-title">
+                      <h1><%= @presenter.title.first %></h1>
+                      <%= @presenter.collection_type_badge %>
+                      <%= @presenter.permission_badge %>
+                  </div>
+              </div>
+
+        <% unless @presenter.total_viewable_items.blank? %>
+            <div class="hyc-bugs">
+              <div class="hyc-item-count">
+                <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %></div>
+                  <% unless @presenter.creator.blank? %>
+                      <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
+                  <% end %>
+                  <% unless @presenter.modified_date.blank? %>
+                      <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
+                  <% end %>
             </div>
+        <% end %>
 
-      <% unless @presenter.total_viewable_items.blank? %>
-          <div class="hyc-bugs">
-            <div class="hyc-item-count">
-              <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %></div>
-                <% unless @presenter.creator.blank? %>
-                    <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
-                <% end %>
-                <% unless @presenter.modified_date.blank? %>
-                    <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
-                <% end %>
-          </div>
-      <% end %>
+        </div>
 
       </div>
-
     </div>
-  </div>
 
-  <div class="row hyc-body">
-    <div class="col-md-8 hyc-description">
-      <%= render 'collection_description', presenter: @presenter %>
+    <div class="row hyc-body">
+      <div class="col-md-8 hyc-description">
+        <%= render 'collection_description', presenter: @presenter %>
 
-      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
-          <div class="hyc-blacklight hyc-bl-title">
-            <h2>
-              <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
-            </h2>
-          </div>
-          <div class="hyc-blacklight hyc-bl-results">
-            <%= render 'show_parent_collections', presenter: @presenter %>
-          </div>
-      <% end %>
+        <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+            <div class="hyc-blacklight hyc-bl-title">
+              <h2>
+                <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
+              </h2>
+            </div>
+            <div class="hyc-blacklight hyc-bl-results">
+              <%= render 'show_parent_collections', presenter: @presenter %>
+            </div>
+        <% end %>
 
+      </div>
     </div>
-  </div>
 
-  <!-- Search results label -->
-  <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
-    <div class="hyc-blacklight hyc-bl-title">
-    <% if collection_search_parameters? %>
-      <h2>
-        <%= t('hyrax.dashboard.collections.show.search_results') %>
-      </h2>
-    <% end %>
-    </div>
-  <% end %>
-
-  <!-- Search bar -->
-  <div class="hyc-blacklight hyc-bl-search hyc-body row">
-    <div class="col">
-      <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
-    </div>
-  </div>
-
-  <!-- Subcollections -->
-  <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
+    <!-- Search results label -->
+    <% if @members_count > 0 || @presenter.subcollection_count > 0 %>
       <div class="hyc-blacklight hyc-bl-title">
-        <h2><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h2>
+      <% if collection_search_parameters? %>
+        <h2>
+          <%= t('hyrax.dashboard.collections.show.search_results') %>
+        </h2>
+      <% end %>
       </div>
-      <div class="hyc-blacklight hyc-bl-results">
-        <%= render 'subcollection_list', collection: @subcollection_docs %>
-      </div>
-  <% end %>
+    <% end %>
 
-  <!-- Works -->
-  <% if @members_count > 0 %>
-      <div class="hyc-blacklight hyc-bl-sort">
-        <%= render 'sort_and_per_page', collection: @presenter %>
+    <!-- Search bar -->
+    <div class="hyc-blacklight hyc-bl-search hyc-body row">
+      <div class="col">
+        <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
       </div>
+    </div>
 
-      <div class="hyc-blacklight hyc-bl-results">
-        <%= render_document_index @member_docs %>
-      </div>
+    <!-- Subcollections -->
+    <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>
+        <div class="hyc-blacklight hyc-bl-title">
+          <h2><%= t('.subcollection_count') %> (<%= @subcollection_count %>)</h2>
+        </div>
+        <div class="hyc-blacklight hyc-bl-results">
+          <%= render 'subcollection_list', collection: @subcollection_docs %>
+        </div>
+    <% end %>
 
-      <div class="hyc-blacklight hyc-bl-pager">
-        <%= render 'paginate' %>
-      </div>
-  <% end # if @members_count > 0 %>
+    <!-- Works -->
+    <% if @members_count > 0 %>
+        <div class="hyc-blacklight hyc-bl-sort">
+          <%= render 'sort_and_per_page', collection: @presenter %>
+        </div>
+
+        <div class="hyc-blacklight hyc-bl-results">
+          <%= render_document_index @member_docs %>
+        </div>
+
+        <div class="hyc-blacklight hyc-bl-pager">
+          <%= render 'paginate' %>
+        </div>
+    <% end # if @members_count > 0 %>
+  </div>
+
+
+  <span class='hide analytics-event' data-category="collection" data-action="collection-page-view" data-name="<%= @presenter.id %>" >
 </div>
-
-
-<span class='hide analytics-event' data-category="collection" data-action="collection-page-view" data-name="<%= @presenter.id %>" >
-

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,56 +1,66 @@
-<div class="alert alert-info">
-  <%= render 'directions' %>
+<div class="container text-center">
+  <h1 class="share-header-text">
+      <%= t('hyrax.contact_form.header') %>
+  </h1>
 </div>
 
-<h1>
-    <%= t('hyrax.contact_form.header') %>
-</h1>
-
-<% if user_signed_in? %>
-  <% nm = current_user.name %>
-  <% em = current_user.email %>
-<% else %>
-  <% nm = '' %>
-  <% em = '' %>
-<% end %>
-
-<%= form_for @contact_form, url: hyrax.contact_form_index_path,
-                            html: { class: 'form-horizontal'} do |f| %>
-  <%= f.text_field :contact_method, class: 'hide' %>
-  <div class="form-group">
-    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
-    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
-    <div class="col-sm-10">
-      <%= f.select 'category', options_for_select(issue_types), {prompt: 'Select issue type'}, {class: 'form-control', required: true } %>
+<div class="section-gw-darkblue">
+  <div class="container">
+    <div class="alert alert-info">
+      <%= render 'directions' %>
     </div>
   </div>
+</div>
 
-  <div class="form-group">
-    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+<div class="section-gw-white container">
+  <div class="gw-white-content">
+    <% if user_signed_in? %>
+      <% nm = current_user.name %>
+      <% em = current_user.email %>
+    <% else %>
+      <% nm = '' %>
+      <% em = '' %>
+    <% end %>
+
+    <%= form_for @contact_form, url: hyrax.contact_form_index_path,
+                                html: { class: 'form-horizontal'} do |f| %>
+      <%= f.text_field :contact_method, class: 'hide' %>
+      <div class="form-group">
+        <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
+        <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
+        <div class="col-sm-10">
+          <%= f.select 'category', options_for_select(issue_types), {prompt: 'Select issue type'}, {class: 'form-control', required: true } %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
+        <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
+        <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
+        <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+        <%= f.invisible_captcha :gwsshoney %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
+        <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+      </div>
+
+      <%= flash[:recaptcha_error] %>
+      <% if @show_checkbox_recaptcha %>
+        <%= recaptcha_tags %>
+      <% else %>
+        <%= recaptcha_v3(action: 'contact', site_key: ENV['RECAPTCHA_SITE_KEY_V3']) %>
+      <% end %>
+      <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
+    <% end %>
   </div>
-
-  <div class="form-group">
-    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
-    <%= f.invisible_captcha :gwsshoney %>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
-  </div>
-
-  <%= flash[:recaptcha_error] %>
-  <% if @show_checkbox_recaptcha %>
-    <%= recaptcha_tags %>
-  <% else %>
-    <%= recaptcha_v3(action: 'contact', site_key: ENV['RECAPTCHA_SITE_KEY_V3']) %>
-  <% end %>
-  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
-<% end %>
+</div>

--- a/app/views/hyrax/content_blocks/templates/agreement.html.erb
+++ b/app/views/hyrax/content_blocks/templates/agreement.html.erb
@@ -1,20 +1,22 @@
-<h1><%= ApplicationController.helpers.application_name %> Deposit Agreement</h1>
-<p>
-I hereby grant to the George Washington University a perpetual royalty-free non-exclusive license  to retain, reproduce and distribute the deposited this work (the Work) in whole or in part, in and from its electronic format. This agreement does not represent a transfer of copyrights to the George Washington University.
-</p>
-<p>
-I understand that the purpose of <%= ApplicationController.helpers.application_name %> is to provide perpetual access to this Work. In order to support that, I agree that the George Washington University may make and keep more than one copy of the Work for purposes of security, backup, preservation and access, and may migrate the Work to any medium or format for the purpose of preservation and access in the future. The University will not make any alteration, other than as allowed by this agreement, to the Work.
-</p>
-<p>
-I represent and warrant to the University that the Work is my original work. I also represent that the Work does not, to the best of my knowledge, infringe or violate any rights of others.
-</p>
-<p>
-I further represent and warrant that I have obtained all necessary rights to permit the University to reproduce and distribute the Work and that any third-party owned content is clearly identified and acknowledged within the Work. 
-</p>
-<p>
-By granting this license, I acknowledge that I have read and agreed to the terms of this agreement and all related <a href="http://compliance.gwu.edu/find-policy">George Washington University policies</a> and <a href="terms"><%= ApplicationController.helpers.application_name %> guidelines</a>.
-</p>
-<p>
-FOR AUTHORIZED DEPOSITORS / DESIGNEES / PROXIES
-I represent that I am the author or that I am authorized by the author(s) to execute this Deposit agreement on behalf of the Author(s).
-</p>
+<div class="container">
+    <h1><%= ApplicationController.helpers.application_name %> Deposit Agreement</h1>
+    <p>
+    I hereby grant to the George Washington University a perpetual royalty-free non-exclusive license  to retain, reproduce and distribute the deposited this work (the Work) in whole or in part, in and from its electronic format. This agreement does not represent a transfer of copyrights to the George Washington University.
+    </p>
+    <p>
+    I understand that the purpose of <%= ApplicationController.helpers.application_name %> is to provide perpetual access to this Work. In order to support that, I agree that the George Washington University may make and keep more than one copy of the Work for purposes of security, backup, preservation and access, and may migrate the Work to any medium or format for the purpose of preservation and access in the future. The University will not make any alteration, other than as allowed by this agreement, to the Work.
+    </p>
+    <p>
+    I represent and warrant to the University that the Work is my original work. I also represent that the Work does not, to the best of my knowledge, infringe or violate any rights of others.
+    </p>
+    <p>
+    I further represent and warrant that I have obtained all necessary rights to permit the University to reproduce and distribute the Work and that any third-party owned content is clearly identified and acknowledged within the Work. 
+    </p>
+    <p>
+    By granting this license, I acknowledge that I have read and agreed to the terms of this agreement and all related <a href="http://compliance.gwu.edu/find-policy">George Washington University policies</a> and <a href="terms"><%= ApplicationController.helpers.application_name %> guidelines</a>.
+    </p>
+    <p>
+    FOR AUTHORIZED DEPOSITORS / DESIGNEES / PROXIES
+    I represent that I am the author or that I am authorized by the author(s) to execute this Deposit agreement on behalf of the Author(s).
+    </p>
+</div>

--- a/app/views/hyrax/content_blocks/templates/terms.html.erb
+++ b/app/views/hyrax/content_blocks/templates/terms.html.erb
@@ -1,84 +1,86 @@
-<h1>Terms of Use for <%= ApplicationController.helpers.application_name %></h1>
-<p>
-1. <strong>General:</strong> Welcome to the <%= ApplicationController.helpers.application_name %> web site (“Site”) maintained by the George Washington University Libraries (“GW”) in support of our mission to disseminate information and research to scholars, educators, and the public. As used in these Terms of Use, the terms "we, "us," and "our" refer to the Libraries and the George Washington University. By accessing or using the Site or any of its content, you accept and agree to be bound by these Terms of Use and all applicable laws. If any of these Terms of Use are unacceptable to you or you do not wish to be bound by these Terms of Use, do not use the Site.
-</p>
+<div class="container">
+    <h1>Terms of Use for <%= ApplicationController.helpers.application_name %></h1>
+    <p>
+    1. <strong>General:</strong> Welcome to the <%= ApplicationController.helpers.application_name %> web site (“Site”) maintained by the George Washington University Libraries (“GW”) in support of our mission to disseminate information and research to scholars, educators, and the public. As used in these Terms of Use, the terms "we, "us," and "our" refer to the Libraries and the George Washington University. By accessing or using the Site or any of its content, you accept and agree to be bound by these Terms of Use and all applicable laws. If any of these Terms of Use are unacceptable to you or you do not wish to be bound by these Terms of Use, do not use the Site.
+    </p>
 
-<p>
-We may change these Terms of Use from time to time without notice. By continuing to access or use the Site or any of its content following the posting of such changes, you agree to be bound by these Terms of Use as modified. Accordingly, you should read these Terms of Use from time to time for any changes.  GW may change, restrict access to, suspend, or discontinue this Site, or any portion of this Site, at any time.
-</p>
+    <p>
+    We may change these Terms of Use from time to time without notice. By continuing to access or use the Site or any of its content following the posting of such changes, you agree to be bound by these Terms of Use as modified. Accordingly, you should read these Terms of Use from time to time for any changes.  GW may change, restrict access to, suspend, or discontinue this Site, or any portion of this Site, at any time.
+    </p>
 
-<p>
-2. <strong>Privacy:</strong>  You understand that any information you submit or provided by you will be treated in the manner described in these Terms of Use and the GW <a href=http://www.gwu.edu/privacy-policy target=”_blank”>Privacy Policy</a>.
-</p>
+    <p>
+    2. <strong>Privacy:</strong>  You understand that any information you submit or provided by you will be treated in the manner described in these Terms of Use and the GW <a href=http://www.gwu.edu/privacy-policy target=”_blank”>Privacy Policy</a>.
+    </p>
 
-<p>
-3. <strong>Copyright and Other Proprietary Rights:</strong> The Site includes text, images, graphics, information, articles, multi-media objects, scholarly projects, and other works protected by copyright, trademark and other laws ("Content"). Some of the Content on this site may include materials from older published works that have passed into the "public domain" under U.S. copyright law. Where such information is known, it is included specifically in the metadata associated with each item of Content. The Site itself and most of the materials held as Content on the Site are protected by copyright and other laws. 
-</p>
+    <p>
+    3. <strong>Copyright and Other Proprietary Rights:</strong> The Site includes text, images, graphics, information, articles, multi-media objects, scholarly projects, and other works protected by copyright, trademark and other laws ("Content"). Some of the Content on this site may include materials from older published works that have passed into the "public domain" under U.S. copyright law. Where such information is known, it is included specifically in the metadata associated with each item of Content. The Site itself and most of the materials held as Content on the Site are protected by copyright and other laws. 
+    </p>
 
-<p>
-Nothing in these Terms of Use or on the Site will be construed as granting you any right or license to use any trademarks, service marks or logos displayed on the Site. You agree not to use or register any name, marks, or logo of the George Washington University for any purpose except with our prior written approval and in accordance with any restrictions required by us.
-</p>
+    <p>
+    Nothing in these Terms of Use or on the Site will be construed as granting you any right or license to use any trademarks, service marks or logos displayed on the Site. You agree not to use or register any name, marks, or logo of the George Washington University for any purpose except with our prior written approval and in accordance with any restrictions required by us.
+    </p>
 
-<p>
-4. <strong>Reserved Rights; Obtaining Permissions:</strong> All rights in the Site and the Content that are not expressly granted are reserved. You agree to use the Site and the Content only in ways that comply with copyright law and all other applicable laws, as well as with these Terms of Use, and that do not infringe or violate anyone's rights. If you wish to make any use of the Content that requires authorization under copyright, trademark or other rights, you agree to obtain all necessary permissions. You are responsible for determining whether permission is needed to make any use of the Content that you wish to make.
-</p>
+    <p>
+    4. <strong>Reserved Rights; Obtaining Permissions:</strong> All rights in the Site and the Content that are not expressly granted are reserved. You agree to use the Site and the Content only in ways that comply with copyright law and all other applicable laws, as well as with these Terms of Use, and that do not infringe or violate anyone's rights. If you wish to make any use of the Content that requires authorization under copyright, trademark or other rights, you agree to obtain all necessary permissions. You are responsible for determining whether permission is needed to make any use of the Content that you wish to make.
+    </p>
 
-<p>
-5. <strong>Special Permissions:</strong> GW does not have the authority to grant or deny special permissions to use images or other Content found on the site beyond those uses that are specifically described in these Terms of Use or as noted specifically on individual items of Content. GW is not able to undertake copyright investigations on behalf of Site users.
-</p>
+    <p>
+    5. <strong>Special Permissions:</strong> GW does not have the authority to grant or deny special permissions to use images or other Content found on the site beyond those uses that are specifically described in these Terms of Use or as noted specifically on individual items of Content. GW is not able to undertake copyright investigations on behalf of Site users.
+    </p>
 
-<p>
-6. <strong><%= ApplicationController.helpers.application_name %> Access Levels:</strong> Where possible, GW makes the Content available to the general public. However, some of the Content on this Site has been made available only to GW community users or other user subgroups by designation of the depositor. Such Content cannot be used, downloaded, or distributed by anyone except such authorized users without the written permission of the depositor.
-</p>
+    <p>
+    6. <strong><%= ApplicationController.helpers.application_name %> Access Levels:</strong> Where possible, GW makes the Content available to the general public. However, some of the Content on this Site has been made available only to GW community users or other user subgroups by designation of the depositor. Such Content cannot be used, downloaded, or distributed by anyone except such authorized users without the written permission of the depositor.
+    </p>
 
-<p>
-7. <strong>Use of <%= ApplicationController.helpers.application_name %> Site and Content:</strong>  Unless otherwise specified, Content that has been made accessible to the general public may be used for non-commercial research, educational, or related academic purposes only. Such uses include personal study, distribution to students, research and scholarship (including computational research uses such as data and text mining, citation extraction, or cross-referencing) as long as you do not sell the Content or sell advertising on any page on which the Content is displayed. If you make an item of Content available to others, you shall do so in accordance with the terms of the rights granted pursuant to the particular item of Content and you will retain with the Content its title, the name of the author(s), a reference to these Terms of Use, any copyright or other proprietary notice included on the original, and any metadata associated with the original. You may not make any translation, adaptation or other derivative work of an item of Content except as authorized under applicable law. You may not sublicense or otherwise transfer your rights in an item of Content, unless specifically authorized by the copyright license granted to the item of Content and will only make Content available to others for use by them under these Terms of Use.
-</p>
+    <p>
+    7. <strong>Use of <%= ApplicationController.helpers.application_name %> Site and Content:</strong>  Unless otherwise specified, Content that has been made accessible to the general public may be used for non-commercial research, educational, or related academic purposes only. Such uses include personal study, distribution to students, research and scholarship (including computational research uses such as data and text mining, citation extraction, or cross-referencing) as long as you do not sell the Content or sell advertising on any page on which the Content is displayed. If you make an item of Content available to others, you shall do so in accordance with the terms of the rights granted pursuant to the particular item of Content and you will retain with the Content its title, the name of the author(s), a reference to these Terms of Use, any copyright or other proprietary notice included on the original, and any metadata associated with the original. You may not make any translation, adaptation or other derivative work of an item of Content except as authorized under applicable law. You may not sublicense or otherwise transfer your rights in an item of Content, unless specifically authorized by the copyright license granted to the item of Content and will only make Content available to others for use by them under these Terms of Use.
+    </p>
 
-<p> 
-8. <strong>Fair Use and Other Lawful Uses:</strong> Nothing in these Terms of Use is intended to restrict or limit you from making uses of Content that, in the absence of rights granted hereunder, would not infringe or violate anyone's copyright, trademark or other rights in such Content. To the extent permitted by law, adaptation of the Content to enable use and access by persons with disabilities is encouraged.
-</p>
+    <p> 
+    8. <strong>Fair Use and Other Lawful Uses:</strong> Nothing in these Terms of Use is intended to restrict or limit you from making uses of Content that, in the absence of rights granted hereunder, would not infringe or violate anyone's copyright, trademark or other rights in such Content. To the extent permitted by law, adaptation of the Content to enable use and access by persons with disabilities is encouraged.
+    </p>
 
-<p>
-9. <strong>Third Party Links:</strong>  Links on the Site to third-party web sites are provided solely as a convenience to you. We do not approve or endorse the content of linked third-party sites, and you agree that we will have no responsibility or liability in connection with your use of any linked third-party sites. If you decide to access linked third-party websites, you do so at your own risk.
-</p>
+    <p>
+    9. <strong>Third Party Links:</strong>  Links on the Site to third-party web sites are provided solely as a convenience to you. We do not approve or endorse the content of linked third-party sites, and you agree that we will have no responsibility or liability in connection with your use of any linked third-party sites. If you decide to access linked third-party websites, you do so at your own risk.
+    </p>
 
-<p>
-10. <strong>Choice of Law/Forum Selection:</strong>  GW is located in Washington, DC.  You agree that any dispute arising out of or relating to these Terms of Use or any Content posted to the Site, including copies and republication thereof, whether based in contract, tort, statutory or other law, will be governed by the laws of the District of Columbia, excluding its conflicts of law provisions. You further consent to the personal jurisdiction of and exclusive venue in the federal and state courts located in and serving the District of Columbia as the legal forum for any such dispute.
-</p>
+    <p>
+    10. <strong>Choice of Law/Forum Selection:</strong>  GW is located in Washington, DC.  You agree that any dispute arising out of or relating to these Terms of Use or any Content posted to the Site, including copies and republication thereof, whether based in contract, tort, statutory or other law, will be governed by the laws of the District of Columbia, excluding its conflicts of law provisions. You further consent to the personal jurisdiction of and exclusive venue in the federal and state courts located in and serving the District of Columbia as the legal forum for any such dispute.
+    </p>
 
-<p>
-11. <strong>User Content Disclaimer:</strong> You understand that when using the Site you will be exposed to Content from a variety of sources and that we are not responsible for the accuracy, usefulness, reliability, or intellectual property rights of or relating to such Content. You further understand and acknowledge that you may be exposed to Content that is inaccurate, offensive, or objectionable and you agree to waive, and hereby do waive, any legal or equitable rights or remedies you have or may have against us with respect thereto. We do not endorse any Content or any opinion, recommendation, or advice expressed therein. We do not have any obligation to monitor any Content or any user communications through the Site.  However, we reserve the right to review Content and to exercise its sole discretion to edit or remove, in whole or in part, any Content at any time and for any reason.
-</p>
+    <p>
+    11. <strong>User Content Disclaimer:</strong> You understand that when using the Site you will be exposed to Content from a variety of sources and that we are not responsible for the accuracy, usefulness, reliability, or intellectual property rights of or relating to such Content. You further understand and acknowledge that you may be exposed to Content that is inaccurate, offensive, or objectionable and you agree to waive, and hereby do waive, any legal or equitable rights or remedies you have or may have against us with respect thereto. We do not endorse any Content or any opinion, recommendation, or advice expressed therein. We do not have any obligation to monitor any Content or any user communications through the Site.  However, we reserve the right to review Content and to exercise its sole discretion to edit or remove, in whole or in part, any Content at any time and for any reason.
+    </p>
 
-<p>
-12.  <strong>Disclaimer of Warranties:</strong> THE SITE AND THE CONTENT ARE PROVIDED "AS IS." TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, WE DISCLAIM ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SITE OR THE CONTENT, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT. 
-</p>
+    <p>
+    12.  <strong>Disclaimer of Warranties:</strong> THE SITE AND THE CONTENT ARE PROVIDED "AS IS." TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, WE DISCLAIM ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SITE OR THE CONTENT, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT. 
+    </p>
 
-<p>
-We make no warranty about the accuracy, reliability, completeness, timeliness, sufficiency or quality of the Site or the Content, nor that any particular Content will continue to be made available. We do not approve or endorse any posted material or content provided by others, including GW authors. We do not warrant that the Site will operate without error or interruption, or that the Site or its server are free of computer viruses or other harmful materials. We make no representation regarding your ability to transmit and receive information from or through the Site and you agree and acknowledge that your ability to access the Site may be impaired. We disclaim any and all liability resulting from or related to such events.
-</p>
+    <p>
+    We make no warranty about the accuracy, reliability, completeness, timeliness, sufficiency or quality of the Site or the Content, nor that any particular Content will continue to be made available. We do not approve or endorse any posted material or content provided by others, including GW authors. We do not warrant that the Site will operate without error or interruption, or that the Site or its server are free of computer viruses or other harmful materials. We make no representation regarding your ability to transmit and receive information from or through the Site and you agree and acknowledge that your ability to access the Site may be impaired. We disclaim any and all liability resulting from or related to such events.
+    </p>
 
-<p>
-13. <strong>Limitations of Liability:</strong> WE MAKE THE SITE AND THE CONTENT AVAILABLE FREE OF CHARGE. YOUR USE OF THE SITE AND THE CONTENT IS AT YOUR OWN SOLE RISK. YOU AGREE THAT WE WILL NOT BE LIABLE TO YOU FOR ANY LOSS OR DAMAGES, EITHER ACTUAL OR CONSEQUENTIAL, ARISING OUT OF OR RELATING TO THESE TERMS OF USE, OR TO YOUR (OR ANY THIRD PARTY'S) USE OR INABILITY TO USE THE SITE, OR TO YOUR PLACEMENT OF CONTENT ON THE SITE, OR TO YOUR RELIANCE UPON INFORMATION OBTAINED FROM OR THROUGH THE SITE. IN PARTICULAR, WE WILL HAVE NO LIABILITY FOR ANY CONSEQUENTIAL, INDIRECT, PUNITIVE, SPECIAL, OR INCIDENTAL DAMAGES, WHETHER FORESEEABLE OR UNFORESEEABLE, (INCLUDING, BUT NOT LIMITED TO, CLAIMS FOR DEFAMATION, ERRORS, LOSS OF DATA, OR INTERRUPTION IN AVAILABILITY OF DATA), ARISING OUT OF OR RELATING TO THESE TERMS OF USE, YOUR USE OR INABILITY TO USE THE SITE, OR YOUR PLACEMENT OF CONTENT ON THE SITE, OR TO YOUR RELIANCE UPON INFORMATION OBTAINED FROM OR THROUGH THE SITE, WHETHER BASED IN CONTRACT, TORT, STATUTORY OR OTHER LAW, TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
-</p>
+    <p>
+    13. <strong>Limitations of Liability:</strong> WE MAKE THE SITE AND THE CONTENT AVAILABLE FREE OF CHARGE. YOUR USE OF THE SITE AND THE CONTENT IS AT YOUR OWN SOLE RISK. YOU AGREE THAT WE WILL NOT BE LIABLE TO YOU FOR ANY LOSS OR DAMAGES, EITHER ACTUAL OR CONSEQUENTIAL, ARISING OUT OF OR RELATING TO THESE TERMS OF USE, OR TO YOUR (OR ANY THIRD PARTY'S) USE OR INABILITY TO USE THE SITE, OR TO YOUR PLACEMENT OF CONTENT ON THE SITE, OR TO YOUR RELIANCE UPON INFORMATION OBTAINED FROM OR THROUGH THE SITE. IN PARTICULAR, WE WILL HAVE NO LIABILITY FOR ANY CONSEQUENTIAL, INDIRECT, PUNITIVE, SPECIAL, OR INCIDENTAL DAMAGES, WHETHER FORESEEABLE OR UNFORESEEABLE, (INCLUDING, BUT NOT LIMITED TO, CLAIMS FOR DEFAMATION, ERRORS, LOSS OF DATA, OR INTERRUPTION IN AVAILABILITY OF DATA), ARISING OUT OF OR RELATING TO THESE TERMS OF USE, YOUR USE OR INABILITY TO USE THE SITE, OR YOUR PLACEMENT OF CONTENT ON THE SITE, OR TO YOUR RELIANCE UPON INFORMATION OBTAINED FROM OR THROUGH THE SITE, WHETHER BASED IN CONTRACT, TORT, STATUTORY OR OTHER LAW, TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
+    </p>
 
-<p>
-14. <strong>Indemnity:</strong> You agree to indemnify and hold harmless GW and its trustees, officers, fellows, students, employees and agents, from and against all claims, actions, suits, damages, liabilities and costs (including, without limitation, reasonable legal fees) arising from or relating to your use of the Site or any of the Content or your failure to comply with any provision of these Terms of Use, and, if applicable, to fully cooperative with GW’s defense against such claims.
-</p>
+    <p>
+    14. <strong>Indemnity:</strong> You agree to indemnify and hold harmless GW and its trustees, officers, fellows, students, employees and agents, from and against all claims, actions, suits, damages, liabilities and costs (including, without limitation, reasonable legal fees) arising from or relating to your use of the Site or any of the Content or your failure to comply with any provision of these Terms of Use, and, if applicable, to fully cooperative with GW’s defense against such claims.
+    </p>
 
-<p>
-15. <strong>Copyright Complaints:</strong>  We respect the intellectual property rights of others. If you are an owner of intellectual property and you believe your intellectual property has been improperly posted or distributed via the Site, please notify us by sending an email to <a href="mailto:copyright@gwu.edu">copyright@gwu.edu</a> or by sending a notice by U.S. Mail to: 2100 Pennsylvania Avenue NW Suite 250, Washington DC 20052, Attention: Legal Department. In your e-mail or letter, you will need to include all of the notice elements listed in the DMCA at 17 U.S.C. § 512(c)(3). Please be aware that the DMCA makes copyright owners liable if they materially misrepresent that a user's content is infringing.
-</p>
+    <p>
+    15. <strong>Copyright Complaints:</strong>  We respect the intellectual property rights of others. If you are an owner of intellectual property and you believe your intellectual property has been improperly posted or distributed via the Site, please notify us by sending an email to <a href="mailto:copyright@gwu.edu">copyright@gwu.edu</a> or by sending a notice by U.S. Mail to: 2100 Pennsylvania Avenue NW Suite 250, Washington DC 20052, Attention: Legal Department. In your e-mail or letter, you will need to include all of the notice elements listed in the DMCA at 17 U.S.C. § 512(c)(3). Please be aware that the DMCA makes copyright owners liable if they materially misrepresent that a user's content is infringing.
+    </p>
 
-<p>
-16. <strong>Communications and Feedback:</strong> We encourage you to contact us in regards to any questions, comments, suggestions, or other feedback you have about the Site. Feedback and any other communications may be sent using the contact form.   You acknowledge and agree that any feedback provided by you to GW is non-confidential and GW shall be entitled to the unrestricted use and dissemination of it for any purpose, commercial or otherwise, without acknowledgement or compensation to you.
-</p>
+    <p>
+    16. <strong>Communications and Feedback:</strong> We encourage you to contact us in regards to any questions, comments, suggestions, or other feedback you have about the Site. Feedback and any other communications may be sent using the contact form.   You acknowledge and agree that any feedback provided by you to GW is non-confidential and GW shall be entitled to the unrestricted use and dissemination of it for any purpose, commercial or otherwise, without acknowledgement or compensation to you.
+    </p>
 
-<p>  
-17. <strong>Termination:</strong> The permissions granted to you in these Terms of Use will terminate automatically upon any breach by you of these Terms of Use. If we take down or otherwise cease to make a work available as an item of Content, the permission granted to you hereunder to use that Content thereafter will terminate at that time. The Site is maintained as a scholarly and educational resource by GW which may be modified or terminated by the University in its sole discretion.
-</p>
+    <p>  
+    17. <strong>Termination:</strong> The permissions granted to you in these Terms of Use will terminate automatically upon any breach by you of these Terms of Use. If we take down or otherwise cease to make a work available as an item of Content, the permission granted to you hereunder to use that Content thereafter will terminate at that time. The Site is maintained as a scholarly and educational resource by GW which may be modified or terminated by the University in its sole discretion.
+    </p>
 
-<p>
-18. <strong>General:</strong>  These Terms of Use constitute the entire agreement between you and GW and with respect to the subject matter herein and supersedes any and all prior or contemporaneous oral or written agreements. These Terms of Use, and any rights and licenses granted hereunder, may not be transferred or assigned by you, but may be assigned by GW without restriction. Any attempted transfer or assignment in violation hereof shall be null and void. The failure of either party to exercise or enforce any right or provision of these Terms of Use shall not constitute a waiver of such right or provision. If any provision of these Terms of Use is found by a court of competent jurisdiction to be invalid, the parties nevertheless agree that the court should endeavor to give effect to the parties' intentions as reflected in the provision, and the other provisions of these Terms of Use remain in full force and effect.
-</p>
+    <p>
+    18. <strong>General:</strong>  These Terms of Use constitute the entire agreement between you and GW and with respect to the subject matter herein and supersedes any and all prior or contemporaneous oral or written agreements. These Terms of Use, and any rights and licenses granted hereunder, may not be transferred or assigned by you, but may be assigned by GW without restriction. Any attempted transfer or assignment in violation hereof shall be null and void. The failure of either party to exercise or enforce any right or provision of these Terms of Use shall not constitute a waiver of such right or provision. If any provision of these Terms of Use is found by a court of competent jurisdiction to be invalid, the parties nevertheless agree that the court should endeavor to give effect to the parties' intentions as reflected in the provision, and the other provisions of these Terms of Use remain in full force and effect.
+    </p>
+</div>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_title, application_name %>
 
-<div class="row home-content">
+<div class="home-content">
   <%= render 'home_content' %>
 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -3,6 +3,7 @@ en:
     controls:
       terms: Information for Authors
       share: Share Your Work
+      browse: Browse Everything
     pages:
       tabs: 
         terms_page: Information for Authors

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Homepage" do
         click_on "Browse Everything"
       end
 
-      expect(current_path).to eq("/browse")
+      expect(current_path).to eq("/catalog")
     end
 
     it 'takes user to search result page when clicking magnifying glass icon' do

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -45,24 +45,10 @@ RSpec.describe "Homepage" do
   end
 
   context "navigation bar" do
-    it 'has a link to "Information for Authors" page' do
-      within ".navigation-wrap" do
-        expect(page).to have_content("Information for Authors")
-      end      
-    end
-
-    it 'takes user to "Information for Authors" page when clicked' do
-      within ".navigation-wrap" do
-        click_on "Information for Authors"
-      end
-
-      expect(current_path).to eq("/terms")
-    end
-
     it 'has a link to "About" page' do
       within ".navigation-wrap" do
         expect(page).to have_content("About")
-      end
+      end      
     end
 
     it 'takes user to "About" page when clicked' do
@@ -73,21 +59,7 @@ RSpec.describe "Homepage" do
       expect(current_path).to eq("/about")
     end
 
-    it 'has a link to the "Help" page' do
-      within ".navigation-wrap" do
-        expect(page).to have_content("Help")
-      end
-    end
-
-    it 'takes user to "Help" page when clicked' do
-      within ".navigation-wrap" do
-        click_on "Help"
-      end
-
-      expect(current_path).to eq("/help")
-    end
-
-    it 'has a link to the "Contact" page' do
+    it 'has a link to "Contact" page' do
       within ".navigation-wrap" do
         expect(page).to have_content("Contact")
       end
@@ -99,6 +71,34 @@ RSpec.describe "Homepage" do
       end
 
       expect(current_path).to eq("/contact")
+    end
+
+    it 'has a link to the "Share Your Work" page' do
+      within ".navigation-wrap" do
+        expect(page).to have_content("Share Your Work")
+      end
+    end
+
+    it 'takes user to "Share Your Work" page when clicked' do
+      within ".navigation-wrap" do
+        click_on "Share Your Work"
+      end
+
+      expect(current_path).to eq("/share")
+    end
+
+    it 'has a link to the "Browse Everything" page' do
+      within ".navigation-wrap" do
+        expect(page).to have_content("Browse Everything")
+      end
+    end
+
+    it 'takes user to "Browse Everything" page when clicked' do
+      within ".navigation-wrap" do
+        click_on "Browse Everything"
+      end
+
+      expect(current_path).to eq("/browse")
     end
 
     it 'takes user to search result page when clicking magnifying glass icon' do

--- a/spec/fixtures/content_blocks/about_page.html
+++ b/spec/fixtures/content_blocks/about_page.html
@@ -1,255 +1,161 @@
-<h1>About GW ScholarSpace</h1>
-<p>As the George Washington University&rsquo;s institutional repository, GW ScholarSpace provides free, public access, broad visibility, and long-term preservation for the research and scholarly works created by GW&rsquo;s faculty, staff and students, including electronic theses and dissertations (ETDs).</p>
-<h2>General Q&amp;A</h2>
-<div id="accordionExample" class="accordion">
-<div class="card">
-    <div id="headingOne" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne"> What works may I contribute to GW ScholarSpace? </button></h3>
+<div class="container">
+    <div class="row text-center">
+        <h1 class="about-header-text">About GW ScholarSpace</h1>
     </div>
-    <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
-        <div class="card-body">
-            <p>Works produced or sponsored by GW faculty, researchers and staff may be shared through GW ScholarSpace, as well as ETDs and student works sponsored by GW faculty or programs.</p>
+</div>
+<div class="section-gw-darkblue">
+    <div class="container">
+        <div style="padding: 1.5em 1em;">
+            <p>As the George Washington University's institutional repository, GW ScholarSpace provides free, public access, broad visibility, and long-term preservation for the research and scholarly works created by GW&rsquo;s faculty, staff and students, including electronic theses and dissertations (ETDs).</p>
+            <p>GW ScholarSpace is maintained by GW Libraries and Academic Innovation (GWLAI).</p>
         </div>
     </div>
 </div>
-
-<div class="card">
-    <div id="headingTwo" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> What types of works are appropriate for GW ScholarSpace? </button></h3>
+<div class="section-gw-white container">
+    <div class="gw-white-content">
+        <h2>What belongs in GW ScholarSpace?</h2>
+        <p>Works produced or sponsored by GW faculty, researchers and staff may be shared through GW ScholarSpace, as well as ETDs and student works sponsored by GW faculty or programs.</p>
+        <p>Appropriate types of works that may be submitted to GW ScholarSpace include, but are not limited to:</p>
+        <ul>
+            <li>Scholarly publications (research & journal articles, books, book reviews, and book chapters)</li>
+            <li>Electronic theses and dissertations (ETDS)</li>
+            <li>Student work (including capstone projects and honors theses)</li>
+            <li>Conference papers and poster presentations</li>
+            <li>Articles, blog posts, and other non-peer reviewed writing</li>
+            <li>Annual reports and newsletters</li>
+            <li>Syllabi and other course materials</li>
+            <li>White papers, working papers, reports, and other non-published documents</li>
+            <li>Fictional and creative works</li>
+        </ul>
     </div>
-    <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionExample">
-        <div class="card-body">
-            <p>Appropriate types of work may include, but are not limited to journal pre-prints and post-prints, datasets, working papers, technical reports, conference papers, student works, annual reports, newsletters, and Electronic Theses and Dissertations (ETDs).</p>
-        </div>
+    <div class="gw-white-content">
+        <h2>Why should I submit my works to GW ScholarSpace?</h2>
+        <h3>Increase the visibility of your work</h3>
+        <p>Including your work in GW ScholarSpace increases the visibility of your research and can increase citations and impact. GW ScholarSpace is open and accessible to all; it is indexed by Google and other search engines. It can provide access to scholarly works that might otherwise only be accessed via subscription.</p>
+        <p>Electronic theses and dissertations in GW ScholarSpace are also discoverable via the <a href="http://go.gwu.edu/primo">GW libraries catalog</a>.</p>
+        <h3>Make Citations Easier with a Persistent Link</h3>
+        <p>All works uploaded to GW ScholarSpace receive persistent links to make citations easier and to ensure long term-access.</p>
+        <h3>Preserve Your Work</h3>
+        <p>GWLAI is committed to providing long-term access to all works submitted to GW ScholarSpace. Informed by best practices, GW Libraries staff use digital preservation strategies that adapt to the changing technological environment.</p>
+        <h3>Comply with the GW Faculty Open Access Resolution</h3>
+        <p>The Open Access Resolution automatically gives GW a non-exclusive right to distribute the works, unless an opt-out waiver has been signed (see <a href="http://library.gwu.edu/about/open-access-faqs#Opting%20Out">Opting Out</a>). When signing publishing agreements for the publication of an article, the author(s) should let the publisher know that the agreement is subject to prior license agreement with The George Washington University. The <a href="https://library.gwu.edu/george-washington-university-addendum-publication-agreement-instructions">Author's Addendum</a> can be found at <a href="">Open Access at GW</a>.</p>
     </div>
-</div>
-
-<div class="card">
-    <div id="headingThree" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree"> What are the advantages of submitting my works to GW ScholarSpace? </button></h3>
+    <div class="gw-white-content">
+        <h2>How do I submit my work to GW ScholarSpace?</h2>
+        <h3>Submitting Electronic Thesis and Dissertations (ETDs)</h3>
+        <p>Electronic Thesis and Dissertations (ETDs) must first be submitted via the ProQuest ETD administrator. Please visit the library’s ETD page for more information.</p>
+        <p>ETDs submitted via this process are automatically ingested into GW ScholarSpace.</p>
+        <h3>Submitting All Other Types of Works and Publications</h3>
+        <p>To deposit any other type of work, please use the <a href="https://library.gwu.edu/scholarspace/submit/">GW ScholarSpace Deposit Form</a>.</p>
     </div>
-    <div id="collapseThree" class="collapse" aria-labelledby="headingThree" data-parent="#accordionExample">
-        <div class="card-body">
-            <ul>
-                <li>Permanent links to each of your scholarly publications ensure long-term access.</li>
-                <li>Enhanced exposure to Google and other search engines increases your works&rsquo; visibility.</li>
-            </ul>
-        </div>
+    <div class="gw-white-content">
+        <h2>What should I know before I deposit something to GW ScholarSpace?</h2>
+        <h3 id="copyright">Copyright and Rights</h3>
+        <p>Any depositor submitting works to GW Scholarspace must either own copyright for the work or have the permission of the copyright holder to publish the work in GW ScholarSpace.</p>
+        <p>Published scholarly work may be subject to copyright restrictions based on the contract signed with the publisher. However, for GW faculty members, depending on the date of publishing, the GW Open Access Resolution may provide GW with nonexclusive permission to make available your scholarly articles and to exercise the copyright in those articles for the purpose of open dissemination.</p>
+        <p>Even without permission or a license, you still may be able to share a pre-print or other form of your research through self-archiving. For more information please visit <a href="https://library.gwu.edu/authors-rights">GW Libraries' guide on author's rights</a>.</p>
+        <p>GW ScholarSpace allows copyright holders to apply specific creative commons licenses to their works. For more information on Creative Commons, please see the <a href="https://creativecommons.org/">Creative Commons official website</a>.</p>
+        <p>For assistance navigating copyright, rights, and permission please contact GW LAI Scholarly Communications team: <a href="mailto:schol_comm@gwu.edu">schol_comm@gwu.edu</a>.</p>
+        <h4>Related Resources:</h4>
+        <p><a href="https://library.gwu.edu/open-access">Open Access - GW Libraries</a><br><a href="https://library.gwu.edu/copyright">Copyright - GW Libraries</a></p>
+        <h3>Deposit Agreement</h3>
+        <p>Please review the <a href="../agreement">GW ScholarSpace Deposit Agreement</a>.</p>
+        <h3>Terms of Use</h3>
+        <p>Please review the <a href="../terms">GW ScholarSpace Terms of Use</a>.</p>
+        <h3 id="accessibility">Accessibility</h3>
+        <p>The George Washington University (GW) is committed to making all web properties and web content accessible and usable for everyone, including people with disabilities, by employing principles of universal design and striving to conform to <a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a>, Level AA.<br>
+            Works submitted to GW ScholarSpace should conform to WCAG 2.1, Level AA. For assistance in making your work comply with the WCAG guidelines please contact the Scholarly Communications team: <a href="mailto:schol_comm@gwu.edu">schol_comm@gwu.edu</a>.</p>
+        <p>Related Resources:<br><a href="https://library.gwu.edu/accessibility-best-practices">Accessibility Best Practices - GW Libraries</a></p>
+        <h3>Visibility and Sharing</h3>
+        <p>Works deposited to GW ScholarSpace are publicly discoverable except where embargoed.</p>
     </div>
-</div>
-
-<div class="card">
-    <div id="headingFour" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour"> Will my works be publicly discoverable? </button></h3>
-    </div>
-    <div id="collapseFour" class="collapse" aria-labelledby="headingFour" data-parent="#accordionExample">
-        <div class="card-body">
-        <p>Yes, GW ScholarSpace is intended for public access. However, if your publisher requires a temporary embargo, we can facilitate that (see <a href="https://scholarspace.library.gwu.edu/about?locale=en#embargoes">Embargoes</a>).</p>
-        </div>
-    </div>
-</div>
-
-<div class="card">
-    <div id="headingFive" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive"> What kinds of materials should not be submitted to GW ScholarSpace? </button></h3>
-    </div>
-    <div id="collapseFive" class="collapse" aria-labelledby="headingFive" data-parent="#accordionExample">
-        <div class="card-body">
-            <p>GW ScholarSpace is not appropriate for works that include sensitive data such as personally identifiable information (PII) or protected health information (PHI).</p>
-        </div>
-    </div>
-</div>
-
-<div class="card">
-    <div id="headingSix" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseSix" aria-expanded="false" aria-controls="collapseSix"> What file formats are accepted in GW ScholarSpace? </button></h3>
-    </div>
-    <div id="collapseSix" class="collapse" aria-labelledby="headingSix" data-parent="#accordionExample">
-        <div class="card-body">
-            <p>GW ScholarSpace welcomes works in most digital formats; however, using <a href="https://scholarspace.library.gwu.edu/about?locale=en#preservation-formats">recommended preservation formats</a> will facilitate long-term preservation and usability.</p>
-        </div>
-    </div>
-</div>
-
-<div class="card">
-    <div id="headingSeven" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven"> What do I need to do before submitting my work to GW ScholarSpace? </button></h3>
-    </div>
-    <div id="collapseSeven" class="collapse" aria-labelledby="headingSeven" data-parent="#accordionExample">
-        <div class="card-body">
-            <p>You must read and agree to the <a href="https://scholarspace.library.gwu.edu/terms">Terms of Use</a> and terms of the <a href="https://scholarspace.library.gwu.edu/agreement">Deposit Agreement</a> in order to submit your works.</p>
-        </div>
-    </div>
-</div>
-
-<div class="card">
-    <div id="headingEight" class="card-header">
-        <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight"> What is a Creative Commons license? </button></h3>
-    </div>
-    <div id="collapseEight" class="collapse" aria-labelledby="headingEight" data-parent="#accordionExample">
-        <div class="card-body">
-            <p>GW ScholarSpace allows copyright holders to apply specific creative commons licenses to their works. For more information on Creative Commons, please see the <a href="https://creativecommons.org/">Creative Commons official website</a>.</p>
-        </div>
-    </div>
-</div>
-</div>
-
-<h2>GW ScholarSpace ETDs</h2>
-<p>As the George Washington University's institutional repository for electronic theses and dissertations (ETDs), GW ScholarSpace provides free, public access, broad visibility, and long-term preservation for ETDs created by GW's students.</p>
-<p>The following information is specific to ETDs in GW ScholarSpace.</p>
-
-<div id="accordionETD" class="accordion">  
-    <div class="card">
-        <div id="ETDheadingOne" class="card-header">
-            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#ETDcollapseOne" aria-expanded="false" aria-controls="ETDcollapseOne"> Will my thesis/dissertation be publicly discoverable? </button></h3>
-        </div>
-        <div id="ETDcollapseOne" class="collapse" aria-labelledby="ETDheadingOne" data-parent="#accordionETD">
-            <div class="card-body">
-                <p>Yes, GW ScholarSpace is intended for public access. However, if your publisher requires a temporary embargo, we can facilitate that (see <a href="https://scholarspace.library.gwu.edu/about?locale=en#embargoes">Embargoes</a> for general and ETD-specific information).</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="card">
-        <div id="ETDheadingTwo" class="card-header">
-            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#ETDcollapseTwo" aria-expanded="false" aria-controls="ETDcollapseTwo"> What kinds of ETD materials may not be in the GW ScholarSpace repository? </button></h3>
-        </div>
-        <div id="ETDcollapseTwo" class="collapse" aria-labelledby="ETDheadingTwo" data-parent="#accordionETD">
-            <div class="card-body">
-                <p>GW ScholarSpace is not appropriate for ETDs or supplementary files that include sensitive data such as personally identifiable information (PII) or protected health information (PHI).</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="card">
-        <div id="ETDheadingThree" class="card-header">
-            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#ETDcollapseThree" aria-expanded="false" aria-controls="ETDcollapseThree"> What file formats are accepted in GW ScholarSpace? </button></h3>
-        </div>
-        <div id="ETDcollapseThree" class="collapse" aria-labelledby="ETDheadingThree" data-parent="#accordionETD">
-            <div class="card-body">
-                <p>GW ScholarSpace welcomes works in most digital formats; however, using <a href="https://scholarspace.library.gwu.edu/about?locale=en#preservation-formats">recommended preservation formats</a> will facilitate long-term preservation and usability. These recommendations apply to ETD and non-ETD works alike.</p>
-            </div>
-        </div>
-    </div>
-</div>
-
-<h2>Using GW ScholarSpace to comply with GW's Open Access Resolution</h2>
-<p>The Open Access Resolution automatically gives GW a non-exclusive right to distribute the works, unless an opt-out waiver has been signed (see <a href="http://library.gwu.edu/about/open-access-faqs#Opting%20Out">Opting Out</a>). When signing publishing agreements for the publication of an article, the author(s) should let the publisher know that the agreement is subject to prior license agreement with The George Washington University. The <a href="https://library.gwu.edu/sites/default/files/communications/AuthorsAddendum17Dec2014.pdf">Author's Addendum</a> can be found at <a href="http://library.gwu.edu/open-access/">Open Access at GW</a>.</p>
-<p>As soon as an article is published, you will be able to upload a copy directly into the GW ScholarSpace repository. Currently, you may submit your work through our Deposit Form and the Library will notify you when the work has been uploaded.</p>
-
-<h2>Depositing your works</h2>
-<div id="accordionDep" class="accordion">  
-    <div class="card">
-        <div id="DepheadingOne" class="card-header">
-            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseOne" aria-expanded="false" aria-controls="DepcollapseOne"> Where do I go to deposit my works to GW ScholarSpace? </button></h3>
-        </div>
-        <div id="DepcollapseOne" class="collapse" aria-labelledby="DepheadingOne" data-parent="#accordionDep">
-            <div class="card-body">
-                <p>To deposit your ETD, please start by visiting <a href="https://library.gwu.edu/etd">the library's ETD page</a>.</p>
-                <p>To deposit any other type of work, please use the <a href="https://library.gwu.edu/scholarspace/submit/">GW ScholarSpace Deposit Form</a>.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="card">
-        <div id="DepheadingTwo" class="card-header">
-            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseTwo" aria-expanded="false" aria-controls="DepcollapseTwo"> What is the maximum size of files that can be uploaded to GW ScholarSpace? </button></h3>
-        </div>
-        <div id="DepcollapseTwo" class="collapse" aria-labelledby="DepheadingTwo" data-parent="#accordionDep">
-            <div class="card-body">
-                <p>For non-ETD works, GW ScholarSpace has an upload size limit of 25 MB. If you would like to upload multiple files or a file larger than 25 MB for a non-ETD work, please send an email to <a href="mailto:scholarspace@gwu.edu">scholarspace@gwu.edu</a>. For all information regarding ETD deposits, please start by visiting <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a>.</p>
-            </div>
-        </div>
-    </div>
-
-    <div class="card">
-        <div id="DepheadingThree" class="card-header">
-            <h3 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#DepcollapseThree" aria-expanded="false" aria-controls="DepcollapseThree"> Do I need to fill in all of the fields on the deposit form when submitting my work? </button></h3>
-        </div>
-        <div id="DepcollapseThree" class="collapse" aria-labelledby="DepheadingThree" data-parent="#accordionDep">
-            <div class="card-body">
-                <p>For non-ETD works, you, or a designated depositor, will need to fill in the required fields on the deposit form and accept the Deposit Agreement before being able to submit your work; however, if you can provide more information about your work in the optional fields provided, it will increase the discoverability of your work within GW ScholarSpace. For all information regarding ETD deposits, please start by visiting <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a>.</p>
+    <div class="gw-white-content">
+        <h2>General Q&A</h2>
+        <div id="accordionQA" class="accordion">
+            <div class="card">
+                <div id="QAheadingOne" class="card-header">
+                    <h3 class="mb-0" id="preservation-formats"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#QAcollapseOne" aria-expanded="false" aria-controls="QAcollapseOne"> Can embargoed work be submitted to GW ScholarSpace? </button></h3>
+                </div>
+                <div id="QAcollapseOne" class="collapse" aria-labeledby="QAheadingOne" data-parent="#accordionQA">
+                    <div class="card-body">
+                        <p>Works deposited to GW ScholarSpace may be embargoed for a limited period.</p>
+                        <p>If a work is embargoed, only the files will be embargoed and hidden from public view; the work's metadata such as title, abstract, author, advisor, etc. is public. Please visit <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a> for more information on embargoes of ETDs.</p>
+                    </div>
+                </div>
+            </div>  
+            <div class="card">
+                <div id="QAheadingTwo" class="card-header">
+                    <h3 class="mb-0" id="preservation-formats"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#QAcollapseTwo" aria-expanded="false" aria-controls="QAcollapseTwo"> What kind of materials should not be submitted to GW ScholarSpace? </button></h3>
+                </div>
+                <div id="QAcollapseTwo" class="collapse" aria-labeledby="QAheadingTwo" data-parent="#accordionQA">
+                    <div class="card-body">
+                        <p>
+                            <ul>
+                                <li>Research data</li>
+                                <li>Works that must be <em>permanently</em> restricted or embargoed</li>
+                                <li>Works that contain confidential information like unredacted personal protected information</li>
+                                <li>Works in which the submitter does not own the copyright or have permission to publish</li>
+                            </ul>
+                        </p>
+                    </div>
+                </div>
+            </div>  
+            <div class="card">
+                <div id="QAheadingThree" class="card-header">
+                    <h3 class="mb-0" id="preservation-formats"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#QAcollapseThree" aria-expanded="false" aria-controls="QAcollapseThree"> What are recommended preservation formats? </button></h3>
+                </div>
+                <div id="QAcollapseThree" class="collapse" aria-labelledby="QAheadingThree" data-parent="#accordionQA">
+                    <div class="card-body">
+                        <p>Recommended preservation formats have been accepted by information technology, archival, and records management professional communities due to multiple factors such as: format longevity, acceptance and use in professional communities, long term accessibility of most viewing software, and incorporated metadata. For more information about digital preservation best practices and standards, please see the Library of Congress <a href="http://www.loc.gov/preservation/resources/rfs/TOC.html">Recommended Formats Statement</a>.</p>
+                        <table border="1" width="496" cellspacing="5px" cellpadding="5px">
+                            <thead>
+                            <tr style="text-align: center;">
+                            <td style="padding: 7px;"><strong>Type</strong></td>
+                            <td style="padding: 7px;"><strong>Recommended Preservation Format</strong></td>
+                            <td style="padding: 7px;"><strong>File Extension</strong></td>
+                            </tr>
+                            </thead>
+                                <tbody>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Text</td>
+                                        <td style="padding: 7px;">PDF/A or PDF</td>
+                                        <td style="padding: 7px; text-align: center;">.pdf</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Text</td>
+                                        <td style="padding: 7px;">Plain Text</td>
+                                        <td style="padding: 7px; text-align: center;">.txt</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Text</td>
+                                        <td style="padding: 7px;">XML</td>
+                                        <td style="padding: 7px; text-align: center;">.xml</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Text</td>
+                                        <td style="padding: 7px;">CSV</td>
+                                        <td style="padding: 7px; text-align: center;">.csv</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Image</td>
+                                        <td style="padding: 7px;">JPEG</td>
+                                        <td style="padding: 7px; text-align: center;">.jpg</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Image</td>
+                                        <td style="padding: 7px;">TIFF</td>
+                                        <td style="padding: 7px; text-align: center;">.tif</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 7px; text-align: center;">Audio</td>
+                                        <td style="padding: 7px;">Broadcast Wave</td>
+                                        <td style="padding: 7px; text-align: center;">.wav</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
-
-<h2>Visibility and Sharing</h2>
-<p>Works deposited to GW ScholarSpace are publicly discoverable except where embargoed.</p>
-
-<h2 id="embargoes">Embargoes</h2>
-<p>Works deposited to GW ScholarSpace may be embargoed for a limited period if required by the publisher (see <a href="http://library.gwu.edu/about/faculty-open-access">Open Access Resolution</a>).</p>
-<p>If a work is embargoed, only the files will be embargoed and hidden from public view; the work's metadata such as title, abstract, author, advisor, etc. is public. Please visit <a href="https://library.gwu.edu/etd">library.gwu.edu/etd</a> for more information on embargoes of ETDs.</p>
-
-<h2>Preservation</h2>
-<p>GWLAI is committed to providing long-term access to all works submitted to GW ScholarSpace. Informed by best practices, GW ScholarSpace and GW Libraries staff use digital preservation strategies that adapt to the changing technological environment.</p>
-<p>For more detailed information about the levels of preservation offered by GW Libraries, please see the <a href="https://library.gwu.edu/digital-stewardship-services">Digital Stewardship Service Catalog</a>. GW ScholarSpace material receives <strong>Tier 1</strong> support.</p>
-<div id="accordionPres" class="accordion">  
-    <div class="card">
-        <div id="PresheadingOne" class="card-header">
-            <h3 class="mb-0" id="preservation-formats"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#PrescollapseOne" aria-expanded="false" aria-controls="PrescollapseOne"> What are recommended preservation formats? </button></h3>
-        </div>
-        <div id="PrescollapseOne" class="collapse" aria-labelledby="PresheadingOne" data-parent="#accordionPres">
-            <div class="card-body">
-                <p>Recommended preservation formats have been accepted by information technology, archival, and records management professional communities due to multiple factors such as: format longevity, acceptance and use in professional communities, long term accessibility of most viewing software, and incorporated metadata. For more information about digital preservation best practices and standards, please see the Library of Congress <a href="http://www.loc.gov/preservation/resources/rfs/TOC.html">Recommended Formats Statement</a>.</p>
-                <table border="1" width="496" cellspacing="5px" cellpadding="5px">
-                    <thead>
-                    <tr style="text-align: center;">
-                    <td style="padding: 7px;"><strong>Type</strong></td>
-                    <td style="padding: 7px;"><strong>Recommended Preservation Format</strong></td>
-                    <td style="padding: 7px;"><strong>File Extension</strong></td>
-                    </tr>
-                    </thead>
-                        <tbody>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Text</td>
-                                <td style="padding: 7px;">PDF/A or PDF</td>
-                                <td style="padding: 7px; text-align: center;">.pdf</td>
-                            </tr>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Text</td>
-                                <td style="padding: 7px;">Plain Text</td>
-                                <td style="padding: 7px; text-align: center;">.txt</td>
-                            </tr>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Text</td>
-                                <td style="padding: 7px;">XML</td>
-                                <td style="padding: 7px; text-align: center;">.xml</td>
-                            </tr>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Text</td>
-                                <td style="padding: 7px;">CSV</td>
-                                <td style="padding: 7px; text-align: center;">.csv</td>
-                            </tr>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Image</td>
-                                <td style="padding: 7px;">JPEG</td>
-                                <td style="padding: 7px; text-align: center;">.jpg</td>
-                            </tr>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Image</td>
-                                <td style="padding: 7px;">TIFF</td>
-                                <td style="padding: 7px; text-align: center;">.tif</td>
-                            </tr>
-                            <tr>
-                                <td style="padding: 7px; text-align: center;">Audio</td>
-                                <td style="padding: 7px;">Broadcast Wave</td>
-                                <td style="padding: 7px; text-align: center;">.wav</td>
-                            </tr>
-                        </tbody>
-                    </table>
-            </div>
-        </div>
-    </div>
-</div>
-
-<h2>Withdrawal</h2>
-<p>Works submitted to GW ScholarSpace are permanent. Under certain circumstances a work in GW ScholarSpace may be removed from view (e.g. due to a violation of the GW ScholarSpace Deposit Agreement). To avoid loss of the historical record, all such instances will be documented via a statement attached to the record in PDF. The content of the document should be: “This work has been withdrawn from GW ScholarSpace. If you have questions, please contact __________.”</p>
-
-<h2>Related University Policies</h2>
-<p><a href="http://library.gwu.edu/about/faculty-open-access/">GW Faculty Open Access Resolution</a></p>
-<p><a href="http://my.gwu.edu/files/policies/CopyrightPolicyFINAL.pdf">GW Copyright Policy</a></p>
-<p><a href="http://my.gwu.edu/files/policies/PublicAccessNIHPublicationsPolicyFINAL.pdf">GW Public Access NIH Publications Policy</a></p>
-<p><a href="http://my.gwu.edu/files/policies/RecordManagementFINAL.pdf">GW Records Management Policy</a></p>
-<p><a href="https://commercialization.gwu.edu/gw-policies">GW Technology Commercialization Office Transfer Policies</a></p>
-<p><a href="http://my.gwu.edu/files/policies/InformationSecurityPolicyFINAL.pdf">GW Information Security Policy</a></p>

--- a/spec/fixtures/content_blocks/share_page.html
+++ b/spec/fixtures/content_blocks/share_page.html
@@ -61,10 +61,10 @@
         <h2>What do I need to know before I deposit my work?</h2>
         <p>
             <ul>
-                <li><a href="../about">Copyright, Permissions, and Rights</a></li>
+                <li><a href="../about#copyright">Copyright, Permissions, and Rights</a></li>
                 <li><a href="../agreement">Deposit Agreement</a></li>
                 <li><a href="../terms">Terms of Use</a></li>
-                <li><a href="../about">Accessibility Requirements</a></li>
+                <li><a href="../about#accessibility">Accessibility Requirements</a></li>
             </ul>
         </p>
         <p>Want more information about GWSS and depositing your works? Browse the GW ScholarSpace <a href="../about">about page</a>. Have questions or need further assistance? <a href="../contact">Contact the Scholarly Communications team from GWLAI</a>.</p>    


### PR DESCRIPTION
Would close #503 and #475. I combined the issues to avoid further git confusion, hopefully it isn't too large of a PR.
This includes:

- navbar restructuring
- anchor links in the new Share Your Work page
- the updated About page
- updated styling for the Contact form
- moved HTML containers to prepare for the new design (some of these are temporary, but looking at the styling has been a bit painful)
- removal of Share Your Work header button styling & CSS
- mobile header redesign (related to lack of share your work button)