### PR TITLE
Add CD redeploy script

### DIFF
--- a/script/cd-redeploy.sh
+++ b/script/cd-redeploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Change directory to the scholarspace folder
+cd /opt/scholarspace/scholarspace-hyrax
+# Stash any local changes
+git stash
+# Checkout master branch if not already on it
+git checkout master
+# Pull any changes
+git pull
+# Stop and remove containers
+docker compose down
+# Remove GHCR Images
+echo "Deleting GHCR Docker iamges"
+docker image rm $(docker images "ghcr.io/gwu-libraries/**" -q)
+# Remove locally built images
+echo "Deleting locally built Docker images"
+docker image rm $(docker images "scholarspace-**" -q)
+# Delete app volume
+echo "Deleting app volume"
+docker volume rm scholarspace-hyrax_app-hyrax
+echo "Restarting Docker containers"
+docker compose up -d
+# If we don't sleep, Docker can't find the user
+sleep 2
+# Precompile Assets
+echo "Precompiling assets"
+docker exec -i --user scholarspace $(docker ps --filter name=app -q) bash -lc "bundle exec rails assets:precompile RAILS_ENV=production"
+# Run rake task to apply any changes to contentblocks used on homepage/about/other main pages
+echo "Applying contentblocks"
+docker exec -i --user scholarspace $(docker ps --filter name=app -q) bash -lc "bundle exec rails gwss:apply_contentblock_changes RAILS_ENV=production"


### PR DESCRIPTION
Working on getting the CD pipeline on test, and going to need to add a modified version of the `redeploy-app.sh` script. I was thinking we just add this alongside that script, since while they're similar, they have separate use cases. 

Changes from initial script:
- Adding git stash/checkout/pulling of changes from the `master` branch
- removing any locally built scholarspace images (which shouldn't impact anything if they don't exist, but should make this work for both GHCR or locally built images)
- changing the `-it` to `-i` in the docker exec commands to avoid an error in Jenkins pipeline about not being a `TTY`
- Adding the content block rake task after the precompiling of assets. 

Not really much to test with this PR, as it shouldn't change any functionality of the actual application.