### PR TITLE
T499 browse route

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -206,15 +206,21 @@ Hyrax.config do |config|
   # config.binaries_directory = "tmp/binaries"
 
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
-  begin
-    if defined? BrowseEverything
-      config.browse_everything = BrowseEverything.config
-    else
-      Rails.logger.warn "BrowseEverything is not installed"
-    end
-  rescue Errno::ENOENT
-    config.browse_everything = nil
-  end
+  # GWSS Customization - this BrowseEverything conditional doesn't seem to be working in our setup
+  # causes an error in _/hyrax-3.6.0/app/views/hyrax/base/_form_files.html.erb
+
+  # begin
+  #   if defined? BrowseEverything
+  #     config.browse_everything = BrowseEverything.config
+  #   else
+  #     Rails.logger.warn "BrowseEverything is not installed"
+  #   end
+  # rescue Errno::ENOENT
+  #   config.browse_everything = nil
+  # end
+
+  # Skipping block and manually setting browse_everything to nil
+  config.browse_everything = nil
 
   ## Whitelist all directories which can be used to ingest from the local file
   # system.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ Rails.application.routes.draw do
 
   mount Bulkrax::Engine, at: '/'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
-  mount BrowseEverything::Engine => '/browse'
-  
+
+  get '/browse', to: redirect('/catalog')
+
   get '/etd/:id', to: redirect('/concern/gw_etds/%{id}')
   get '/etds/:id', to: redirect('/concern/gw_etds/%{id}')
   get '/files/:id', to: redirect('concern/gw_works/%{id}')

--- a/spec/features/browse_route_spec.rb
+++ b/spec/features/browse_route_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Browse route" do
+
+  it 'redirects users to /catalog when visiting /browse' do
+    visit "/browse"
+
+    expect(current_path).to eq("/catalog")
+  end
+
+end


### PR DESCRIPTION
Will fix #499

To test:
- Run rspec tests
- Visit `/browse` and ensure you are rerouted to `/catalog` instead of receiving a rails error. 