### PR TITLE
Blocking notifications and importer/exporter pages for non-privileged… 

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,8 +1,10 @@
 <ul id="user_utility_links" class="nav navbar-nav navbar-right">
   <% if user_signed_in? %>
-    <li>
-      <%= render_notifications(user: current_user) %>
-    </li>
+    <% if current_user.admin? || current_user.contentadmin? %>
+      <li>
+        <%= render_notifications(user: current_user) %>
+      </li>
+    <% end %>
     <li class="dropdown">
       <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
         <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,13 +56,23 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
 
+
 Hyrax::Engine.routes.draw do
   get 'share' =>'pages#show', key: 'share'
-  # Redirects non-privileged users to the application homepage
-  authenticate :user, lambda { |u| !u.admin? && !u.contentadmin?} do
-    namespace :dashboard do
-      match '(*any)', to: redirect('/'), via: [:get, :post]
-    end 
-  end
+  redirect_all_proc = Proc.new { match '(*any)', to: redirect('/'), via: [:get, :post] }
 
+  # Redirects non-privileged users to the application homepage
+  authenticate :user, lambda { |u| !u.admin? && !u.contentadmin? } do
+    namespace :dashboard, &redirect_all_proc
+    namespace :notifications, &redirect_all_proc
+  end
+end
+
+Bulkrax::Engine.routes.draw do
+  # Redirects non-privileged users to the application homepage
+  redirect_all_proc = Proc.new { match '(*any)', to: redirect('/'), via: [:get, :post] }
+  authenticate :user, lambda { |u| !u.admin? && !u.contentadmin? } do
+    namespace :importers, &redirect_all_proc
+    namespace :exporters, &redirect_all_proc
+  end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -15,6 +15,78 @@ RSpec.describe "Dashboard page" do
 
   end
 
+  it 'redirects authenticated, non-admin, user to homepage when visiting /notifications' do
+
+    non_admin_user = FactoryBot.create(:user)
+
+    sign_in_user(non_admin_user)
+
+    visit '/notifications'
+
+    expect(current_path).to eq(root_path)
+
+  end
+
+  it 'allows authenticated admin user to visit /notifications' do
+
+    admin_user = FactoryBot.create(:admin_user)
+
+    sign_in_user(admin_user)
+
+    visit '/notifications'
+
+    expect(current_path).to eq("/notifications")
+
+  end
+
+  it 'redirects authenticated, non-admin, user to homepage when visiting /importers' do
+
+    non_admin_user = FactoryBot.create(:user)
+
+    sign_in_user(non_admin_user)
+
+    visit '/importers'
+
+    expect(current_path).to eq(root_path)
+
+  end
+
+  it 'allows authenticated admin user to visit /importers' do
+
+    admin_user = FactoryBot.create(:admin_user)
+
+    sign_in_user(admin_user)
+
+    visit '/importers'
+
+    expect(current_path).to eq("/importers")
+
+  end
+
+  it 'redirects authenticated, non-admin, user to homepage when visiting /exporters' do
+
+    non_admin_user = FactoryBot.create(:user)
+
+    sign_in_user(non_admin_user)
+
+    visit '/exporters'
+
+    expect(current_path).to eq(root_path)
+
+  end
+
+  it 'allows authenticated admin user to visit /exporters' do
+
+    admin_user = FactoryBot.create(:admin_user)
+
+    sign_in_user(admin_user)
+
+    visit '/exporters'
+
+    expect(current_path).to eq("/exporters")
+
+  end
+
   it 'displays all admin controls when logged in as an admin user' do
     admin_user = FactoryBot.create(:admin_user)
 


### PR DESCRIPTION
Resolves #529.

 The `notifications`, `importers` and `exporters` routes should now redirect to home for any user who authenticates with non-elevated privileges. Also, the notifications bell should not appear when logged in as such a user.

Note that the code in `routes.rb` is a little redundant; I couldn't see an easy way of getting around it, but if you do, please fix!
