### PR TITLE
Fixes #539 - corrects property used in `citation_publication_date` meta tag

### DIFF
--- a/config/schoolie.yml
+++ b/config/schoolie.yml
@@ -5,6 +5,7 @@ attributes:
   citation_author: creator
   citation_type: resource_type
   dc.type: resource_type
-  citation_date: publication_date
+  citation_publication_date: date_created
+  dc.issued: date_created
   citation_keywords: keyword
   citation_pdf_url: download_url


### PR DESCRIPTION
To test, view the source for an ETD.   Confirm that it contains `citation_publication_date` and `dc.issued` and that the value of each of these contains the date (`date_created`) from the ETD, which should be in YYYY format. 