### PR TITLE
Restore hidden field tag for advanced search submit

### DIFF
--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,5 +1,7 @@
 <div class="submit-buttons">
     <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn-base gw-ghost-btn advanced-search-start-over" %>
 
+    <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
+    
     <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn-base gw-btn advanced-search-submit', :id => "advanced-search-submit" %>
 </div>


### PR DESCRIPTION
PR to fix a bug where the search fields were not being included in advanced search after we removed the search sort options. 

To test:

Visit "/advanced" and try searching with text in "All Fields", "Creator", or any of the other left-side search fields. Ensure the results are accurate. 