### PR TITLE
Base image installation moved to separate Dockerfile

### DIFF
--- a/.github/workflows/ci-cache.yml
+++ b/.github/workflows/ci-cache.yml
@@ -8,8 +8,8 @@ on:
     branches:
       - master
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
-#env:
-#  REGISTRY: ghcr.io
+env:
+  REGISTRY: ghcr.io
 jobs:
   CI:
     runs-on: ubuntu-latest
@@ -19,12 +19,12 @@ jobs:
     steps:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
-#      - name: Log in to the Container registry
-#        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-#        with:
-#          registry: ${{ env.REGISTRY }}
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create scholarspace folders
         run: |
           mkdir -p /opt/scholarspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,8 @@
-# When upgrading passenger-ruby image version, make sure to update passenger version in Gemfile
-FROM phusion/passenger-ruby27:2.5.0
+FROM ghcr.io/gwu-libraries/scholarspace-base:latest
 
 LABEL org.opencontainers.image.source=https://github.com/gwu-libraries/scholarspace-hyrax
 LABEL org.opencontainers.image.description="Dockerized version of our Hyrax application, GW ScholarSpace"
 LABEL org.opencontainers.image.licenses="MIT"
-
-RUN apt update && apt install -y libpq-dev unzip clamav-daemon curl libreoffice libcurl4-openssl-dev ffmpeg gnupg2 libxml2 libxml2-dev wget
-
-RUN apt update && apt build-dep -y imagemagick
-
-RUN apt install -y checkinstall libwebp-dev libopenjp2-7-dev librsvg2-dev libde265-dev
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN cd /opt \
-    && wget https://www.imagemagick.org/archive/releases/ImageMagick-7.1.1-13.tar.xz \
-    && tar xf ImageMagick-7.1.1-13.tar.xz \
-    && cd ImageMagick-7.1.1-13 \
-    && ./configure --enable-shared --with-modules --with-gslib \
-    && make \
-    && make install \
-    && ldconfig /usr/local/lib \
-    && identify -version \
-    && rm /opt/ImageMagick-7.1.1-13.tar.xz
-
-# FITS install
-WORKDIR /usr/local/bin
-
-RUN wget https://github.com/harvard-lts/fits/releases/download/1.5.0/fits-1.5.0.zip \
-    && unzip fits-1.5.0.zip -d fits-1.5.0 \
-    && rm fits-1.5.0.zip \
-    && chmod a+x fits-1.5.0/fits*.sh
-    
-# Uninstall Ruby version from image and install our version
-# bash -lc is necessary per the configuration of the base image 
-RUN bash -lc "rvm remove ruby-2.7.7 && rvm install ruby-2.7.3"
 
 # Hyrax directories
 RUN mkdir -p /opt/scholarspace/scholarspace-hyrax \ 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,0 +1,35 @@
+# When upgrading passenger-ruby image version, make sure to update passenger version in Gemfile
+FROM phusion/passenger-ruby27:2.5.0
+
+LABEL org.opencontainers.image.source=https://github.com/gwu-libraries/scholarspace-hyrax
+
+RUN apt update && apt install -y libpq-dev unzip clamav-daemon curl libreoffice libcurl4-openssl-dev ffmpeg gnupg2 libxml2 libxml2-dev wget
+
+RUN apt update && apt build-dep -y imagemagick
+
+RUN apt install -y checkinstall libwebp-dev libopenjp2-7-dev librsvg2-dev libde265-dev
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN cd /opt \
+    && wget https://www.imagemagick.org/archive/releases/ImageMagick-7.1.1-13.tar.xz \
+    && tar xf ImageMagick-7.1.1-13.tar.xz \
+    && cd ImageMagick-7.1.1-13 \
+    && ./configure --enable-shared --with-modules --with-gslib \
+    && make \
+    && make install \
+    && ldconfig /usr/local/lib \
+    && identify -version \
+    && rm /opt/ImageMagick-7.1.1-13.tar.xz
+
+# FITS install
+WORKDIR /usr/local/bin
+
+RUN wget https://github.com/harvard-lts/fits/releases/download/1.5.0/fits-1.5.0.zip \
+    && unzip fits-1.5.0.zip -d fits-1.5.0 \
+    && rm fits-1.5.0.zip \
+    && chmod a+x fits-1.5.0/fits*.sh
+    
+# Uninstall Ruby version from image and install our version
+# bash -lc is necessary per the configuration of the base image 
+RUN bash -lc "rvm remove ruby-2.7.7 && rvm install ruby-2.7.3"


### PR DESCRIPTION
The non-Ruby dependencies have been moved to a separate Docker image, from which the `scholarspace-app` image (the main `Dockerfile`) inherits. The base image (`scholarspace-base`) has been pushed to the GHCR, so when building the app image locally, the hosted base image will be used, which should expedite the CI/CD workflow. 

## To Test
- On your dev server, remove the existing `scholarspace-app` image then rebuild the latter locally, verifying that the image builds as expected.
- Verify that the app runs as expected.

## Post-merge tasks
- I'll set up a new GitHub Action that will be triggered only upon changes to `Dockerfile-base`, which will build the image and push the updated image to the GHCR.