### PR TITLE
T565 update font on homepage

### DIFF
--- a/app/assets/stylesheets/scholarspace/components/_advanced.scss
+++ b/app/assets/stylesheets/scholarspace/components/_advanced.scss
@@ -16,7 +16,7 @@
             border-bottom: none;
             color: $gw-white;
             font-size: 5vw;
-            font-weight: bold;
+            font-weight: 200;
         }
 
         @media (max-width: 950px) {

--- a/app/assets/stylesheets/scholarspace/components/_homepage.scss
+++ b/app/assets/stylesheets/scholarspace/components/_homepage.scss
@@ -270,6 +270,7 @@
                     h3 {
                       font-size: 1em;
                       text-decoration: underline;
+                      font-weight: 200;
                       --max-lines: 4;
                       --line-height: 1.2;
                       max-height: calc(var(--max-lines) * 1em * var(--line-height));
@@ -446,7 +447,7 @@
                   border-radius: 50%;
                   background-color: $gw-dark-blue;
                   color: $gw-white;
-                  font-weight: bold;
+                  font-weight: 200;
                   font-size: 1.5em;
                   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
     

--- a/app/assets/stylesheets/scholarspace/components/_homepage.scss
+++ b/app/assets/stylesheets/scholarspace/components/_homepage.scss
@@ -30,7 +30,7 @@
       margin-bottom: 0.5em;
       color: $gw-light-blue;
       font-size: 10.5vw;
-      font-weight: bold;
+      font-weight: 200;
       line-height: 0.8em;
 
       @media (min-width: $mobile-breakpoint) {

--- a/app/assets/stylesheets/scholarspace/components/_static-page.scss
+++ b/app/assets/stylesheets/scholarspace/components/_static-page.scss
@@ -4,7 +4,7 @@
     margin-bottom: 0;
     color: $gw-light-blue;
     font-size: 7.5vw;
-    font-weight: bold;
+    font-weight: 200;
 
     @media (min-width: 1786px) {
         font-size: 6.5em;
@@ -46,7 +46,7 @@
     margin-bottom: 0;
     color: $gw-light-blue;
     font-size: 7.5vw;
-    font-weight: bold;
+    font-weight: 200;
 
     @media (min-width: $mobile-breakpoint) {
         font-size: 6.4vw;


### PR DESCRIPTION
Changed font on homepage to the version Geneva requested (this one, it's still Gibson but no longer bold):
![gwss with unbolded gibson](https://github.com/user-attachments/assets/ff9a806d-5bf9-4431-9cec-e3483880bccd)

I also changed the font weight from bold to 200 on "Recently Submitted," "Featured Collections," and h1 headers on static pages (contact, advanced search, share your work, about) because we are no longer tied to Gibson Bold now that it's out of our homepage design. It looks nice!