### PR TITLE
t570 - Tasks to update existing GwETDs with proquest zipfile name, and to download only new ETDs from S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,8 @@ gem 'blacklight_range_limit'
 
 gem 'blacklight_advanced_search'
 
+gem 'aws-sdk-s3', '~> 1'
+
 group :development, :test do
   gem 'pry' # temporily removing, seems to break something with sidekiq in development mode
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1062,6 +1062,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   blacklight_advanced_search
   blacklight_oai_provider (~> 6.1.1)
   blacklight_range_limit

--- a/app/forms/hyrax/gw_etd_form.rb
+++ b/app/forms/hyrax/gw_etd_form.rb
@@ -4,10 +4,10 @@ module Hyrax
 #  class GwEtdForm < Hyrax::Forms::WorkForm
   class GwEtdForm < GwWorkForm
     self.model_class = ::GwEtd
-    self.terms += [:degree, :advisor, :committee_member]
+    self.terms += [:degree, :advisor, :committee_member, :proquest_zipfile]
 
     def secondary_terms
-      super + [:degree, :advisor, :committee_member]
+      super + [:degree, :advisor, :committee_member, :proquest_zipfile]
     end
   end
 end

--- a/app/models/gw_etd.rb
+++ b/app/models/gw_etd.rb
@@ -32,5 +32,9 @@ class GwEtd < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :proquest_zipfile, predicate: ::RDF::URI("http://scholarspace.library.gwu.edu/ns#proquest_zipfile"), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   include ::Hyrax::BasicMetadata
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -77,6 +77,7 @@ en:
         volume:                 "Volume Number"
         issue:                  "Issue Number"
         permanent_url:          "Persistent URL"
+        proquest_zipfile:       "ProQuest ZIP file name"
     hints:
       defaults:
         title: 'The name of the work.'

--- a/example.env
+++ b/example.env
@@ -93,3 +93,9 @@ UID_ATTRIBUTE=
 
 # If reindexing, need to set this value. Several works with location information require it. 
 GEONAMES_USERNAME=""
+
+# These are used to download ProQuest ETDs from AWS S3
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=
+AWS_PROQUEST_ETD_BUCKET_NAME=proquest-etds

--- a/lib/tasks/ingest_bulkrax_prep.rake
+++ b/lib/tasks/ingest_bulkrax_prep.rake
@@ -189,7 +189,7 @@ namespace :gwss do
     end
 
     bulkrax_files_path = "#{bulkrax_zip_path}/files" 
-    FileUtils.makedirs("#{bulkrax_files_path}") unless File.exists?(bulkrax_zip_path)
+    FileUtils.makedirs("#{bulkrax_files_path}") unless File.exists?(bulkrax_files_path)
 
     # get all ETD zip files in the args.filepath folder
     path_to_zips = args.filepath
@@ -221,6 +221,7 @@ namespace :gwss do
       etd_doc = get_etd_doc(xml_file_path)
       puts "xml is located at: #{xml_file_path}"
       etd_md = extract_metadata(etd_doc)
+      etd_md['proquest_zipfile'] = zip_file_basename + '.zip'
       parent_work_identifier = SecureRandom.uuid
       etd_md['bulkrax_identifier'] = parent_work_identifier
       works_metadata << etd_md

--- a/lib/tasks/s3_etd_tasks.rake
+++ b/lib/tasks/s3_etd_tasks.rake
@@ -1,0 +1,129 @@
+require 'fileutils'
+require 'aws-sdk-s3'
+require 'nokogiri'
+require 'rake'
+require 'zip'
+require 'csv'
+
+namespace :gwss do
+  # Build index of ETD PDF file name --> Proquest zip file name
+  # using proquest ETDs as ground truth
+  # look in bulkrax code to borrow code for unzipping etc.
+  desc "Adds ProQuest zipfile names to metadata of current GwETDs"
+  task :populate_etd_proquest_zipfile => :environment do
+    # Builds a hash that maps each proquest zip file name to its PDF file name,
+    # for all ProQuest ETD zip files in S3
+    def build_pq_mapping_hash
+      puts "Building a hash mapping ETD PDF file names to proquest zip file names"
+      pq_hash = {}
+      
+      bucket_name = ENV['AWS_PROQUEST_ETD_BUCKET_NAME']
+      s3_bucket_client = Aws::S3::Bucket.new(name: bucket_name)
+       
+      # Set up a temporary location to open up one zip at a time
+      destination_dir = './temp_pq_etds' 
+      Dir.mkdir(destination_dir) unless Dir.exist?(destination_dir)
+
+      # List out all the zip file names
+      object_name_list = s3_bucket_client.objects.map(&:key)
+      object_name_list.each do |object_name|
+        obj_client = Aws::S3::Object.new(bucket_name: bucket_name, key: object_name)
+
+        # Download the proquest zip file
+        destination_path = File.join(destination_dir, File.basename(object_name))
+        obj_client.get(response_target: destination_path)
+
+        # Open it up, find the XML file, convert that to PDF file name (they always match)
+        Zip::File.open(destination_path) do |zip_file|
+          data_xml_files = zip_file.select { |entry| entry.name.match?(/\_DATA.xml$/i) }
+          pdf_fn = data_xml_files[0].name.gsub('_DATA.xml', '.pdf')
+          pq_hash[pdf_fn] = object_name
+          puts "\t#{object_name} --> #{pdf_fn}"
+        end
+
+        # Clean up
+        File.delete(destination_path)
+      end
+      return pq_hash
+    end
+    
+    # Returns hash of existing GwETD ids to PDF file names
+    def build_etd_pdf_hash
+      puts "Mapping each existing GwETD id to its PDF file name"
+      etd_pdf_hash = {}
+      GwEtd.find_each do |etd|
+        etd_id = etd.id
+        fsets = etd.file_sets
+        fn_list = fsets.map(&:label)
+        pattern = /\w*_gwu_0075A_\w*\.pdf/
+        matching_files = fn_list.select { |filename| filename.match?(pattern) }
+
+        etd_pdf_hash[etd_id] = matching_files[0]
+        puts "\t#{etd_id} => #{matching_files[0]}"
+      end
+      return etd_pdf_hash
+    end
+    
+    # Adds proquest_zipfile values to current GwETDs
+    def enrich_etds(etdfn_to_zipfn, etdid_to_etdfn)
+      puts "Adding proquest_zipfile values to GwETDs..."
+      etdid_to_etdfn.each do |etdid, etdfn|
+        puts "\t#{etdid}...#{etdfn}"
+        etd = GwEtd.find(etdid)
+        unless etdfn.nil?
+          etd['proquest_zipfile'] = etdfn_to_zipfn[etdfn]
+          etd.save
+        end
+      end
+    end
+
+    # Build mapping hash (ETD PDF file name => pq original zip file name)
+    pq_hash = build_pq_mapping_hash()
+    # Map GwEtd ID => ETD PDF file name
+    etd_pdf_hash = build_etd_pdf_hash()
+    # Update GwEtd objects' metadata
+    enrich_etds(pq_hash, etd_pdf_hash)
+  end
+
+  # Check for proquest zips in S3 that don't yet exist in GWSS
+  # Download them from S3 to the path specified in the argument.
+  desc "Download ProQuest zip files not matching ETDs currently in GWSS"
+  task :download_new_pq_zips, [:filepath] => :environment do |t, args|
+    
+    # Returns a list of the ProQuest zip files currently in S3
+    def get_s3_pq_zip_names
+      bucket_name = ENV['AWS_PROQUEST_ETD_BUCKET_NAME']
+      s3_bucket_client = Aws::S3::Bucket.new(name: bucket_name)
+      object_name_list = s3_bucket_client.objects.map(&:key)
+      object_name_list
+    end
+
+    # Returns a Set of the zipfile names in the proquest_zipfile metadata values
+    # of current GwETD works
+    def get_gwss_pq_zipfiles_set
+      etds = GwEtd.all
+      etd_zipfiles_list = etds.map(&:proquest_zipfile)
+      etd_zipfiles_set = Set.new(etd_zipfiles_list)
+      etd_zipfiles_set
+    end
+
+    # Download a list of specific ProQuest zip files from S3
+    def download_s3_pq_zipfiles(destination_dir, zf_list)
+      bucket_name = ENV['AWS_PROQUEST_ETD_BUCKET_NAME']
+      zf_list.each do |zf_name|
+        obj_client = Aws::S3::Object.new(bucket_name: bucket_name, key: zf_name)
+        destination_path = File.join(destination_dir, File.basename(zf_name))
+        obj_client.get(response_target: destination_path)
+        puts "Downloading #{zf_name} to #{destination_dir}"
+      end
+    end
+    
+    s3_pq_zipnames = get_s3_pq_zip_names()
+    etd_zipfiles_set = get_gwss_pq_zipfiles_set()
+    # Do a "diff" to get only zipfiles that are NOT associated with current GwETDs
+    new_proquest_zipfiles = s3_pq_zipnames.reject {|zf| etd_zipfiles_set.include?(zf)} 
+
+    path_to_zips = args.filepath
+    download_s3_pq_zipfiles(path_to_zips, new_proquest_zipfiles)
+  end
+end

--- a/spec/features/bulkrax_upload_spec.rb
+++ b/spec/features/bulkrax_upload_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe "Deposit files through Bulkrax" do
     print headers_arr
     expect(headers_arr).to eq(["model", "title", "creator", "contributor", "language",
                                "description", "keyword", "degree", "resource_type", "advisor", "gw_affiliation",
-                               "date_created", "committee_member", "rights_statement", "license", "bulkrax_identifier",
-                               "file", "parents", "visibility", "visibility_during_embargo",
+                               "date_created", "committee_member", "rights_statement", "license", "proquest_zipfile",
+                               "bulkrax_identifier", "file", "parents", "visibility", "visibility_during_embargo",
                                "visibility_after_embargo", "embargo_release_date"])
 
     # check that there are five rows - one for header, one for each of the etds, one for each of the files


### PR DESCRIPTION
Fixes #570.

## To test:

### BEFORE switching to this branch
...so, while on the `main` branch, download a few ETDs from the `proquest-etds` bucket, copy them to `/opt/scholarspace/scholarspace-ingest`.
- Also upload these same ETDs to the `proquest-etds-test2` S3 bucket. 
- Run the `gwss:ingest_pq_etds` task.  Then, do a bulkrax import. See https://github.com/gwu-libraries/scholarspace-hyrax/wiki/Bulkrax-imports for details.  Make sure to clear out the `/opt/scholarspace/scholarspace-ingest` folder as well as the `/opt/scholarspace/scholarspace-hyrax/tmp/bulkrax_zip` folder afterwards.

### AFTER switching to this branch

- Populate `.env` with the new credential values at the bottom of `example.env`.   There is a bucket called `proquest-etds-test2` (in `us-east-1`) that you can use.  You can either create an additional, new credential pair, or contact @kerchner for existing credentials.
- Ensure that the `proquest-etds-test2` contains some ProQuest ETDs (zip files) that your environment does _not_ already have.  You can copy a few more ProQuest ETDs over from `proquest-etds` to accomplish this.
- Run the `gwss:populate_etd_proquest_zipfile` task.  Edit one of the GwETDs and observe that `proquest_zipfile` is (correctly) populated
- Add a few more ETDs from the `proquest-etds` S3 bucket to `proquest-etds-test-2`.
- Run the `gwss:download_new_pq_zips` task.  Observe that the "new" ETDs have been downloaded to `/opt/scholarspace/scholarspace-ingest`
- Run the `gwss:ingest_pq_etds` task.  Then, do a bulkrax import. See https://github.com/gwu-libraries/scholarspace-hyrax/wiki/Bulkrax-imports for details.  Observe (via the work edit form) that the newly loaded ETDs are populated with `proquest_zipfile` values.