### PR TITLE
Fixes #598 - adds Isisfiles_Artifact fields to catalog view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -130,6 +130,11 @@ class CatalogController < ApplicationController
     # config.add_index_field solr_name("identifier", :stored_searchable), label: "Identifier", helper_method: :index_field_link, field_name: 'identifier'
     config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
+    config.add_index_field solr_name("title_romanized", :stored_searchable), label: "Title (Romanized)"
+    config.add_index_field solr_name("contributor_romanized", :stored_searchable), label: "Contributor (Romanized)"
+    config.add_index_field solr_name("corporate_contributor", :stored_searchable), label: "Corporate Contributor"
+    config.add_index_field solr_name("corporate_contributor_romanized", :stored_searchable), label: "Corporate Contributor (Romanized)"
+    config.add_index_field solr_name("date_created_islamic", :stored_searchable), label: "Date, Hijri"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/views/hyrax/isisfiles_artifacts/_attribute_rows.erb
+++ b/app/views/hyrax/isisfiles_artifacts/_attribute_rows.erb
@@ -12,6 +12,7 @@
 <%= presenter.attribute_to_html(:based_near_label, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
+<%= presenter.attribute_to_html(:gw_affiliation, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true) %>


### PR DESCRIPTION
Metadata fields for `Isisfiles_Artifact` catalog results view should match metadata fields showing for these works on https://isisfiles.gwu.edu .

Also, Isisfiles_Artifact landing page should show **GW Unit** (which will be populated in the import with `GW Program on Extremism`)